### PR TITLE
Fix wrong vault path in pcloud playbook

### DIFF
--- a/ansible/playbooks/install_pcloud.yml
+++ b/ansible/playbooks/install_pcloud.yml
@@ -4,6 +4,6 @@
   connection: local
   become: yes
   vars_files:
-    - roles/pcloud/vars/vault.yml
+    - ../roles/pcloud/vars/vault.yml
   roles:
     - pcloud


### PR DESCRIPTION
## Summary
- fix the relative path to the pcloud vault variables file

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68402e8ad8808322a49cf015144d7cc3