### PR TITLE
Add ArgoCD role

### DIFF
--- a/ansible/playbooks/install_argocd.yml
+++ b/ansible/playbooks/install_argocd.yml
@@ -1,0 +1,7 @@
+---
+- name: Install ArgoCD
+  hosts: localhost
+  connection: local
+  become: yes
+  roles:
+    - argocd

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -6,3 +6,5 @@ collections:
     version: ">=6.0.0"
   - name: community.docker
     version: ">=3.0.0"
+  - name: kubernetes.core
+    version: ">=2.3.0"

--- a/ansible/roles/argocd/defaults/main.yml
+++ b/ansible/roles/argocd/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+argocd_version: "2.9.5"

--- a/ansible/roles/argocd/tasks/main.yml
+++ b/ansible/roles/argocd/tasks/main.yml
@@ -1,0 +1,31 @@
+# ansible/roles/argocd/tasks/main.yml
+---
+- name: Install prerequisites
+  ansible.builtin.apt:
+    name:
+      - curl
+      - kubectl
+    state: present
+    update_cache: yes
+  become: yes
+
+- name: Download ArgoCD CLI
+  ansible.builtin.get_url:
+    url: "https://github.com/argoproj/argo-cd/releases/download/v{{ argocd_version }}/argocd-linux-amd64"
+    dest: /usr/local/bin/argocd
+    mode: '0755'
+  become: yes
+
+- name: Create ArgoCD namespace
+  kubernetes.core.k8s:
+    api_version: v1
+    kind: Namespace
+    name: argocd
+    state: present
+
+- name: Install ArgoCD in cluster
+  ansible.builtin.shell: |
+    kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/v{{ argocd_version }}/manifests/install.yaml
+  args:
+    executable: /bin/bash
+  become: yes

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -6,3 +6,4 @@
     - docker
     - ufw
     - pcloud
+    - argocd


### PR DESCRIPTION
## Summary
- add default variables for an ArgoCD role
- install ArgoCD through a new role and playbook
- require kubernetes.core collection
- include argocd role in `site.yml`

## Testing
- `pip install ansible ansible-lint` *(fails: Could not find a version that satisfies the requirement ansible)*

------
https://chatgpt.com/codex/tasks/task_e_68403e85a3288322bf9ee8fe31176bc3