### PR TITLE
Update setup script with git install and repo clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@ Orchestration Oasis is an infrastructure automation project built around **Ansib
 ## Setup
 
 Run the helper script to install Docker and Ansible on a fresh Debian system.
-The script is non-interactive and skips packages that are already installed:
+The script is non-interactive, installs Git and optionally clones a repository
+if a URL is provided. It skips packages that are already installed:
 
 ```bash
-./scripts/setup-debian.sh
+./scripts/setup-debian.sh <repo_url>
 ```
 
 

--- a/scripts/setup-debian.sh
+++ b/scripts/setup-debian.sh
@@ -2,6 +2,9 @@
 # Install Docker and Ansible on Debian-based systems
 set -euo pipefail
 
+# Optional repository URL to clone
+REPO_URL="${1:-}"
+
 if [ "$(id -u)" -ne 0 ]; then
     SUDO='sudo'
 else
@@ -9,7 +12,11 @@ else
 fi
 
 $SUDO apt-get update
-$SUDO apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release software-properties-common
+$SUDO apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release software-properties-common git
+
+if [ -n "$REPO_URL" ]; then
+    git clone "$REPO_URL"
+fi
 
 # Install Ansible if not present
 if ! command -v ansible >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- add optional repo URL argument to `setup-debian.sh`
- install Git and clone repo when provided
- document new behavior in README

## Testing
- `bash -n scripts/setup-debian.sh`
- `pip install ansible-lint` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68407c4ae46083228d089293129f2b72