### PR TITLE
Fix yamllint issues

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,7 @@
 ---
 name: Lint Code Base
 
-on:
+"on":
   push:
     branches: [main]
   pull_request:

--- a/ansible/playbooks/roles/pcloud/tasks/main.yml
+++ b/ansible/playbooks/roles/pcloud/tasks/main.yml
@@ -1,7 +1,15 @@
 ---
 - name: Retrieve pCloud token from Bitwarden
   ansible.builtin.set_fact:
-    pcloud_token: "{{ lookup('bitwarden.secrets', 'item', item_id=token_item_id, client_id=client_id, client_secret=client_secret, password=password) }}"
+    pcloud_token: >-
+      {{ lookup(
+        'bitwarden.secrets',
+        'item',
+        item_id=token_item_id,
+        client_id=client_id,
+        client_secret=client_secret,
+        password=password,
+      ) }}
 
 - name: Install rclone
   ansible.builtin.apt:


### PR DESCRIPTION
## Summary
- fix yamllint boolean warning in GitHub Actions workflow
- wrap Bitwarden lookup in pcloud role to avoid line-length error

## Testing
- `yamllint .`
- `ansible-lint site.yml`
- `shellcheck scripts/setup-debian.sh`


------
https://chatgpt.com/codex/tasks/task_e_6841836a69ec83229ff1264eac33d3dc