### PR TITLE
Add lint script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ cd ansible
 ansible-playbook -i <inventory> site.yml
 ```
 
+## Linting
+
+Use the helper script to run `yamllint` and `ansible-lint` locally:
+
+```bash
+./scripts/run-lint.sh
+```
+
+The script automatically sets `ANSIBLE_CONFIG` to `ansible/ansible.cfg`. If you
+can't run the Docker-based Super-Linter locally, rely on the GitHub workflow to
+perform the additional checks.
+
 ## Tasks Remaining for V1 (Debian 12, Bitwarden Web API)
 
 1. [x] **Verify Linting**:

--- a/scripts/run-lint.sh
+++ b/scripts/run-lint.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Run yamllint and ansible-lint with project configuration
+set -euo pipefail
+
+# Run yamllint using relaxed rules
+if command -v yamllint >/dev/null 2>&1; then
+    yamllint -d "{extends: relaxed}" .
+else
+    echo "yamllint is not installed" >&2
+fi
+
+# Run ansible-lint using local ansible.cfg
+if command -v ansible-lint >/dev/null 2>&1; then
+    ANSIBLE_CONFIG=ansible/ansible.cfg ansible-lint "$@"
+else
+    echo "ansible-lint is not installed" >&2
+fi
+


### PR DESCRIPTION
## Summary
- add a helper script to run yamllint and ansible-lint
- document local linting via the script

## Testing
- `./scripts/run-lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_6841869b7c9483229a3ecfcc295198fd