### PR TITLE
Fix README list indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,48 +37,48 @@ perform the additional checks.
 ## Tasks Remaining for V1 (Debian 12, Bitwarden Web API)
 
 1. [x] **Verify Linting**:
-   - Re-run Super-Linter to confirm:
+    - Re-run Super-Linter to confirm:
      ```bash
      docker run --rm -v $(pwd):/github/workspace -e VALIDATE_ALL_CODEBASE=true -e VALIDATE_MARKDOWN=true -e VALIDATE_YAML=true -e VALIDATE_ANSIBLE=true -e DEFAULT_BRANCH=main github/super-linter:v5
      ```
-   - If warnings appear for `pcloud/templates/rclone.conf.j2` or `rclone-pcloud.service.j2`, add `---`.
-   - `---` has been added to these templates to satisfy the linter.
+    - If warnings appear for `pcloud/templates/rclone.conf.j2` or `rclone-pcloud.service.j2`, add `---`.
+    - `---` has been added to these templates to satisfy the linter.
 
 2. [x] **Remove `dummy.yml`**:
-   - ```bash
-     git rm scripts/dummy.yml
-     git commit -m "Remove dummy.yml for V1"
-     ```
+    ```bash
+    git rm scripts/dummy.yml
+    git commit -m "Remove dummy.yml for V1"
+    ```
 
 3. [x] **Integrate Bitwarden Web API**:
-   - Delete `ansible/playbooks/roles/pcloud/vars/vault.yml`:
+    - Delete `ansible/playbooks/roles/pcloud/vars/vault.yml`:
      ```bash
      git rm ansible/playbooks/roles/pcloud/vars/vault.yml
      ```
-   - Update `install_pcloud.yml` (remove `vars_files`).
-   - Update `site.yml` (remove `vars_files`).
-   - Modify `pcloud/tasks/main.yml` to use Bitwarden API (authentication, token retrieval).
-   - Update `.ansible-lint` (remove `exclude_paths`).
+    - Update `install_pcloud.yml` (remove `vars_files`).
+    - Update `site.yml` (remove `vars_files`).
+    - Modify `pcloud/tasks/main.yml` to use Bitwarden API (authentication, token retrieval).
+    - Update `.ansible-lint` (remove `exclude_paths`).
 
 4. [ ] **Add Validations to Roles**:
-   - `docker`: Verify service and `docker ps`.
-   - `pcloud`: Verify `/mnt/pcloud` mount.
-   - `ufw`: Verify `ufw status`.
+    - `docker`: Verify service and `docker ps`.
+    - `pcloud`: Verify `/mnt/pcloud` mount.
+    - `ufw`: Verify `ufw status`.
 
 5. [ ] **Configure Molecule**:
-   - Create Molecule files for `docker` and `pcloud` (use `debian:12` image).
-   - Update `.github/workflows/lint.yml` with Molecule tests.
+    - Create Molecule files for `docker` and `pcloud` (use `debian:12` image).
+    - Update `.github/workflows/lint.yml` with Molecule tests.
 
 6. [ ] **Create Documentation**:
-   - Create `docs/` with `docker.md`, `pcloud.md`, `ufw.md`.
-   - Copy `ansible/playbooks/roles/pcloud/readme.md` to `docs/pcloud.md`.
+    - Create `docs/` with `docker.md`, `pcloud.md`, `ufw.md`.
+    - Copy `ansible/playbooks/roles/pcloud/readme.md` to `docs/pcloud.md`.
 
 7. [ ] **Add Inventory**:
-   - Create `examples/inventory.yml` with Bitwarden variables (`client_id`, `client_secret`, `password`, `token_item_id`).
+    - Create `examples/inventory.yml` with Bitwarden variables (`client_id`, `client_secret`, `password`, `token_item_id`).
 
 8. [ ] **Test on Debian 12**:
-  - Run playbooks, verify services (Docker, pCloud, UFW, Semaphore).
-   - Test Molecule locally:
+    - Run playbooks, verify services (Docker, pCloud, UFW, Semaphore).
+    - Test Molecule locally:
      ```bash
      pip install molecule[docker] docker
      cd ansible/playbooks/roles/docker
@@ -86,7 +86,7 @@ perform the additional checks.
      ```
 
 9. [ ] **Tag V1**:
-   - ```bash
-     git tag v1.0.0
-     git push --tags
-     ```
+    ```bash
+    git tag v1.0.0
+    git push --tags
+    ```


### PR DESCRIPTION
## Summary
- align nested bullet points with 4 spaces to satisfy markdownlint
- drop hyphens before code blocks to satisfy MD040 warnings

## Testing
- `./scripts/run-lint.sh` *(fails: yamllint and ansible-lint not installed)*
- `markdownlint README.md`


------
https://chatgpt.com/codex/tasks/task_e_68418b2e7a188322bb0b238123cf5f19