### PR TITLE
Add playbook for Semaphore

### DIFF
--- a/ansible/playbooks/install_semaphore.yml
+++ b/ansible/playbooks/install_semaphore.yml
@@ -1,0 +1,6 @@
+---
+- name: Install and configure Semaphore
+  hosts: all
+  become: true
+  roles:
+    - semaphore


### PR DESCRIPTION
## Summary
- add missing playbook to deploy the semaphore role

## Testing
- `./scripts/run-lint.sh` *(fails: yamllint and ansible-lint not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684192dd3a388322a95e3a04efbceec4