### PR TITLE
Add Prometheus install role

### DIFF
--- a/ansible/playbooks/install_prometheus.yml
+++ b/ansible/playbooks/install_prometheus.yml
@@ -1,0 +1,6 @@
+---
+- name: Install and configure Prometheus
+  hosts: all
+  become: true
+  roles:
+    - prometheus

--- a/ansible/playbooks/roles/prometheus/defaults/main.yml
+++ b/ansible/playbooks/roles/prometheus/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+prometheus_version: "latest"
+prometheus_dir: "/opt/prometheus"

--- a/ansible/playbooks/roles/prometheus/readme.md
+++ b/ansible/playbooks/roles/prometheus/readme.md
@@ -1,0 +1,10 @@
+# Prometheus Role
+
+Deploys [Prometheus](https://prometheus.io/) using Docker Compose.
+
+## Variables
+
+- `prometheus_version`: Docker image tag (default `latest`)
+- `prometheus_dir`: Directory for the compose file (default `/opt/prometheus`)
+
+Store sensitive values outside version control if required.

--- a/ansible/playbooks/roles/prometheus/tasks/main.yml
+++ b/ansible/playbooks/roles/prometheus/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+- name: Ensure Prometheus directory exists
+  ansible.builtin.file:
+    path: "{{ prometheus_dir }}"
+    state: directory
+    mode: '0755'
+
+- name: Deploy Prometheus config
+  ansible.builtin.template:
+    src: prometheus.yml.j2
+    dest: "{{ prometheus_dir }}/prometheus.yml"
+    mode: '0644'
+
+- name: Deploy docker-compose file
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
+    dest: "{{ prometheus_dir }}/docker-compose.yml"
+    mode: '0644'
+
+- name: Launch Prometheus stack
+  community.docker.docker_compose_v2:
+    project_src: "{{ prometheus_dir }}"
+    state: present
+  register: prometheus_compose
+
+- name: Display compose status
+  ansible.builtin.debug:
+    var: prometheus_compose

--- a/ansible/playbooks/roles/prometheus/templates/docker-compose.yml.j2
+++ b/ansible/playbooks/roles/prometheus/templates/docker-compose.yml.j2
@@ -1,0 +1,12 @@
+version: '3'
+services:
+  prometheus:
+    image: prom/prometheus:{{ prometheus_version }}
+    restart: unless-stopped
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus_data:/prometheus
+    ports:
+      - "9090:9090"
+volumes:
+  prometheus_data:

--- a/ansible/playbooks/roles/prometheus/templates/prometheus.yml.j2
+++ b/ansible/playbooks/roles/prometheus/templates/prometheus.yml.j2
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']


### PR DESCRIPTION
## Summary
- create Prometheus role with docker-compose deployment
- add playbook `install_prometheus.yml`

## Testing
- `./scripts/run-lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_684198000ebc8322baad02a8f7ec2827