### PR TITLE
Add Windows Chocolatey role

### DIFF
--- a/ansible/playbooks/install_chocolatey.yml
+++ b/ansible/playbooks/install_chocolatey.yml
@@ -1,0 +1,5 @@
+---
+- name: Install Chocolatey
+  hosts: windows
+  roles:
+    - chocolatey

--- a/ansible/playbooks/roles/chocolatey/defaults/main.yml
+++ b/ansible/playbooks/roles/chocolatey/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+chocolatey_state: "present"

--- a/ansible/playbooks/roles/chocolatey/readme.md
+++ b/ansible/playbooks/roles/chocolatey/readme.md
@@ -1,0 +1,7 @@
+# Chocolatey Role
+
+Installs [Chocolatey](https://chocolatey.org/) on Windows hosts using the `win_chocolatey` module from the `chocolatey.chocolatey` collection.
+
+## Variables
+
+- `chocolatey_state`: Installation state for Chocolatey (`present` or `absent`). Defaults to `present`.

--- a/ansible/playbooks/roles/chocolatey/tasks/main.yml
+++ b/ansible/playbooks/roles/chocolatey/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Ensure Chocolatey is installed
+  chocolatey.chocolatey.win_chocolatey:
+    name: chocolatey
+    state: "{{ chocolatey_state }}"

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -6,3 +6,5 @@ collections:
     version: ">=6.0.0"
   - name: community.docker
     version: ">=3.0.0"
+  - name: chocolatey.chocolatey
+    version: ">=1.0.0"


### PR DESCRIPTION
## Summary
- install Chocolatey on Windows via new `chocolatey` role
- document the role
- add install playbook
- declare required collection

## Testing
- `./scripts/run-lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_6841b4dedf04832285f2395d6f9c0b86