### PR TITLE
Add VLC role

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Orchestration Oasis
 
-Orchestration Oasis is an infrastructure automation project built around **Ansible**. It currently features roles for Docker, UFW, pCloud, and Semaphore to help configure a Debian 12 server. The list below tracks the remaining work before the first stable release.
+Orchestration Oasis is an infrastructure automation project built around **Ansible**. It currently features roles for Docker, UFW, pCloud, and Semaphore to help configure a Debian 12 server. Windows hosts can also be provisioned using Chocolatey, with a dedicated role to install VLC. The list below tracks the remaining work before the first stable release.
 
 ## Setup
 

--- a/ansible/playbooks/install_vlc.yml
+++ b/ansible/playbooks/install_vlc.yml
@@ -1,0 +1,5 @@
+---
+- name: Install VLC media player
+  hosts: windows
+  roles:
+    - vlc

--- a/ansible/playbooks/roles/vlc/defaults/main.yml
+++ b/ansible/playbooks/roles/vlc/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+vlc_state: "present"

--- a/ansible/playbooks/roles/vlc/readme.md
+++ b/ansible/playbooks/roles/vlc/readme.md
@@ -1,0 +1,7 @@
+# VLC Role
+
+Installs [VLC media player](https://www.videolan.org/vlc/) on Windows hosts using the `win_chocolatey` module from the `chocolatey.chocolatey` collection.
+
+## Variables
+
+- `vlc_state`: Installation state for VLC (`present` or `absent`). Defaults to `present`.

--- a/ansible/playbooks/roles/vlc/tasks/main.yml
+++ b/ansible/playbooks/roles/vlc/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Ensure VLC is installed
+  chocolatey.chocolatey.win_chocolatey:
+    name: vlc
+    state: "{{ vlc_state }}"


### PR DESCRIPTION
## Summary
- add Ansible role to install VLC via Chocolatey on Windows hosts
- provide playbook `install_vlc.yml`
- document new role in README

## Testing
- `./scripts/run-lint.sh` *(fails: yamllint and ansible-lint not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6841b6efade8832299c3ff67bc64ea8b