### PR TITLE
Add combined Windows playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ cd ansible
 ansible-playbook -i <inventory> site.yml
 ```
 
+For Windows hosts, you can install Chocolatey and VLC in one step:
+
+```bash
+ansible-playbook -i <inventory> playbooks/install_chocolatey_and_vlc.yml
+```
+
+The playbooks `install_chocolatey.yml` and `install_vlc.yml` remain available if you prefer to run them separately.
+
 ## Linting
 
 Use the helper script to run `yamllint` and `ansible-lint` locally:

--- a/ansible/playbooks/install_chocolatey_and_vlc.yml
+++ b/ansible/playbooks/install_chocolatey_and_vlc.yml
@@ -1,0 +1,6 @@
+---
+- name: Install Chocolatey and VLC
+  hosts: windows
+  roles:
+    - chocolatey
+    - vlc


### PR DESCRIPTION
## Summary
- add a playbook to install Chocolatey and VLC in one run
- document Windows playbook usage in README

## Testing
- `./scripts/run-lint.sh` *(fails: yamllint is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6841bc0799208322bc1d6445bcc98c56