### PR TITLE
Add Fail2ban role

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Orchestration Oasis
 
-Orchestration Oasis is an infrastructure automation project built around **Ansible**. It currently features roles for Docker, UFW, pCloud, and Semaphore to help configure a Debian 12 server. Windows hosts can also be provisioned using Chocolatey, with a dedicated role to install VLC. The list below tracks the remaining work before the first stable release.
+Orchestration Oasis is an infrastructure automation project built around **Ansible**. It currently features roles for Docker, UFW, Fail2ban, pCloud, and Semaphore to help configure a Debian 12 server. Windows hosts can also be provisioned using Chocolatey, with a dedicated role to install VLC. The list below tracks the remaining work before the first stable release.
 
 ## Setup
 

--- a/ansible/playbooks/install_fail2ban.yml
+++ b/ansible/playbooks/install_fail2ban.yml
@@ -1,0 +1,6 @@
+---
+- name: Install and configure Fail2ban
+  hosts: fail2ban
+  become: true
+  roles:
+    - fail2ban

--- a/ansible/playbooks/roles/fail2ban/defaults/main.yml
+++ b/ansible/playbooks/roles/fail2ban/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+fail2ban_bantime: 3600
+fail2ban_findtime: 600
+fail2ban_maxretry: 5

--- a/ansible/playbooks/roles/fail2ban/tasks/main.yml
+++ b/ansible/playbooks/roles/fail2ban/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+- name: Install fail2ban package
+  ansible.builtin.apt:
+    name: fail2ban
+    state: present
+    update_cache: true
+  become: true
+
+- name: Deploy fail2ban configuration
+  ansible.builtin.template:
+    src: jail.local.j2
+    dest: /etc/fail2ban/jail.local
+    mode: '0644'
+  become: true
+
+- name: Ensure fail2ban is enabled and running
+  ansible.builtin.service:
+    name: fail2ban
+    enabled: true
+    state: started
+  become: true

--- a/ansible/playbooks/roles/fail2ban/templates/jail.local.j2
+++ b/ansible/playbooks/roles/fail2ban/templates/jail.local.j2
@@ -1,0 +1,8 @@
+# ansible/playbooks/roles/fail2ban/templates/jail.local.j2
+[DEFAULT]
+bantime = {{ fail2ban_bantime }}
+findtime = {{ fail2ban_findtime }}
+maxretry = {{ fail2ban_maxretry }}
+
+[sshd]
+enabled = true

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -5,5 +5,6 @@
   roles:
     - docker
     - ufw
+    - fail2ban
     - pcloud
     - semaphore


### PR DESCRIPTION
## Summary
- add Fail2ban role with defaults, template and tasks
- allow installing Fail2ban via `install_fail2ban.yml`
- include Fail2ban in `site.yml`
- mention Fail2ban support in README

## Testing
- `scripts/run-lint.sh` *(fails: yamllint and ansible-lint not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6841c8933fe08322a93502befe1b8697