### PR TITLE
Add Chrome, Thunderbird and Notepad++ roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ cd ansible
 ansible-playbook -i <inventory> site.yml
 ```
 
-For Windows hosts, you can install Chocolatey and VLC in one step:
+For Windows hosts, you can install Chocolatey along with VLC, Google Chrome,
+Thunderbird and Notepad++ in one step:
 
 ```bash
 ansible-playbook -i <inventory> playbooks/install_chocolatey_and_vlc.yml

--- a/ansible/playbooks/install_chocolatey_and_vlc.yml
+++ b/ansible/playbooks/install_chocolatey_and_vlc.yml
@@ -1,6 +1,9 @@
 ---
-- name: Install Chocolatey and VLC
+- name: Install Chocolatey and desktop apps
   hosts: windows
   roles:
     - chocolatey
     - vlc
+    - chrome
+    - thunderbird
+    - notepadplusplus

--- a/ansible/playbooks/roles/chrome/defaults/main.yml
+++ b/ansible/playbooks/roles/chrome/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+chrome_state: "present"

--- a/ansible/playbooks/roles/chrome/tasks/main.yml
+++ b/ansible/playbooks/roles/chrome/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Ensure Google Chrome is installed
+  chocolatey.chocolatey.win_chocolatey:
+    name: googlechrome
+    state: "{{ chrome_state }}"

--- a/ansible/playbooks/roles/notepadplusplus/defaults/main.yml
+++ b/ansible/playbooks/roles/notepadplusplus/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+notepadplusplus_state: "present"

--- a/ansible/playbooks/roles/notepadplusplus/tasks/main.yml
+++ b/ansible/playbooks/roles/notepadplusplus/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Ensure Notepad++ is installed
+  chocolatey.chocolatey.win_chocolatey:
+    name: notepadplusplus
+    state: "{{ notepadplusplus_state }}"

--- a/ansible/playbooks/roles/thunderbird/defaults/main.yml
+++ b/ansible/playbooks/roles/thunderbird/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+thunderbird_state: "present"

--- a/ansible/playbooks/roles/thunderbird/tasks/main.yml
+++ b/ansible/playbooks/roles/thunderbird/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Ensure Thunderbird is installed
+  chocolatey.chocolatey.win_chocolatey:
+    name: thunderbird
+    state: "{{ thunderbird_state }}"


### PR DESCRIPTION
## Summary
- add Windows roles for Google Chrome, Thunderbird and Notepad++
- update playbook to include the new desktop apps
- mention these apps in the README

## Testing
- `./scripts/run-lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_6841edc7502c8322a44d1cddd9a4124d