### PR TITLE
Ensure Chocolatey installs for all users

### DIFF
--- a/ansible/playbooks/roles/chocolatey/defaults/main.yml
+++ b/ansible/playbooks/roles/chocolatey/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 chocolatey_state: "present"
+chocolatey_install_args: "ALLUSERS=1"

--- a/ansible/playbooks/roles/chocolatey/tasks/main.yml
+++ b/ansible/playbooks/roles/chocolatey/tasks/main.yml
@@ -3,8 +3,10 @@
   chocolatey.chocolatey.win_chocolatey:
     name: chocolatey
     state: "{{ chocolatey_state }}"
+    install_args: "{{ chocolatey_install_args }}"
 
 - name: Ensure all Chocolatey packages are up to date
   chocolatey.chocolatey.win_chocolatey:
     name: all
     state: latest
+    install_args: "{{ chocolatey_install_args }}"

--- a/ansible/playbooks/roles/chrome/tasks/main.yml
+++ b/ansible/playbooks/roles/chrome/tasks/main.yml
@@ -3,3 +3,4 @@
   chocolatey.chocolatey.win_chocolatey:
     name: googlechrome
     state: "{{ chrome_state }}"
+    install_args: "{{ chocolatey_install_args }}"

--- a/ansible/playbooks/roles/git/tasks/main.yml
+++ b/ansible/playbooks/roles/git/tasks/main.yml
@@ -3,3 +3,4 @@
   chocolatey.chocolatey.win_chocolatey:
     name: git
     state: "{{ git_state }}"
+    install_args: "{{ chocolatey_install_args }}"

--- a/ansible/playbooks/roles/notepadplusplus/tasks/main.yml
+++ b/ansible/playbooks/roles/notepadplusplus/tasks/main.yml
@@ -3,3 +3,4 @@
   chocolatey.chocolatey.win_chocolatey:
     name: notepadplusplus
     state: "{{ notepadplusplus_state }}"
+    install_args: "{{ chocolatey_install_args }}"

--- a/ansible/playbooks/roles/thunderbird/tasks/main.yml
+++ b/ansible/playbooks/roles/thunderbird/tasks/main.yml
@@ -3,3 +3,4 @@
   chocolatey.chocolatey.win_chocolatey:
     name: thunderbird
     state: "{{ thunderbird_state }}"
+    install_args: "{{ chocolatey_install_args }}"

--- a/ansible/playbooks/roles/vlc/tasks/main.yml
+++ b/ansible/playbooks/roles/vlc/tasks/main.yml
@@ -3,3 +3,4 @@
   chocolatey.chocolatey.win_chocolatey:
     name: vlc
     state: "{{ vlc_state }}"
+    install_args: "{{ chocolatey_install_args }}"


### PR DESCRIPTION
## Summary
- set default install arguments for Chocolatey role
- pass install arguments to Windows package installs via Chocolatey
- keep Ansible lints happy

## Testing
- `./scripts/run-lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_684203d684308322a6c0ebceb81f8698