### PR TITLE
Add GeForce Now role

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Orchestration Oasis
 
-Orchestration Oasis is an infrastructure automation project built around **Ansible**. It currently features roles for Docker, UFW, Fail2ban, pCloud, and Semaphore to help configure a Debian 12 server. Windows hosts can also be provisioned using Chocolatey, with roles to install VLC, Google Chrome, Thunderbird, Notepad++, Git, and GeForce Now. The list below tracks the remaining work before the first stable release.
+Orchestration Oasis is an infrastructure automation project built around **Ansible**. It currently features roles for Docker, UFW, Fail2ban, pCloud, and Semaphore to help configure a Debian 12 server.
+Windows hosts can also be provisioned using Chocolatey, with roles to install VLC, Google Chrome, Thunderbird, Notepad++, Git, and GeForce Now.
+The list below tracks the remaining work before the first stable release.
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Orchestration Oasis
 
-Orchestration Oasis is an infrastructure automation project built around **Ansible**. It currently features roles for Docker, UFW, Fail2ban, pCloud, and Semaphore to help configure a Debian 12 server. Windows hosts can also be provisioned using Chocolatey, with roles to install VLC, Google Chrome, Thunderbird, Notepad++, and Git. The list below tracks the remaining work before the first stable release.
+Orchestration Oasis is an infrastructure automation project built around **Ansible**. It currently features roles for Docker, UFW, Fail2ban, pCloud, and Semaphore to help configure a Debian 12 server. Windows hosts can also be provisioned using Chocolatey, with roles to install VLC, Google Chrome, Thunderbird, Notepad++, Git, and GeForce Now. The list below tracks the remaining work before the first stable release.
 
 ## Setup
 
@@ -23,7 +23,7 @@ ansible-playbook -i <inventory> site.yml
 ```
 
 For Windows hosts, you can install Chocolatey along with VLC, Google Chrome,
-Thunderbird, Notepad++ and Git in one step:
+Thunderbird, Notepad++, Git and GeForce Now in one step:
 
 ```bash
 ansible-playbook -i <inventory> playbooks/install_chocolatey_and_vlc.yml

--- a/ansible/playbooks/install_chocolatey_and_vlc.yml
+++ b/ansible/playbooks/install_chocolatey_and_vlc.yml
@@ -8,3 +8,4 @@
     - thunderbird
     - notepadplusplus
     - git
+    - geforcenow

--- a/ansible/playbooks/roles/geforcenow/defaults/main.yml
+++ b/ansible/playbooks/roles/geforcenow/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+geforcenow_state: "present"

--- a/ansible/playbooks/roles/geforcenow/readme.md
+++ b/ansible/playbooks/roles/geforcenow/readme.md
@@ -1,0 +1,7 @@
+# GeForce Now Role
+
+Installs [NVIDIA GeForce Now](https://www.nvidia.com/en-us/geforce-now/) on Windows hosts using the `win_chocolatey` module from the `chocolatey.chocolatey` collection.
+
+## Variables
+
+- `geforcenow_state`: Installation state for GeForce Now (`present` or `absent`). Defaults to `present`.

--- a/ansible/playbooks/roles/geforcenow/tasks/main.yml
+++ b/ansible/playbooks/roles/geforcenow/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Ensure GeForce Now is installed
+  chocolatey.chocolatey.win_chocolatey:
+    name: nvidia-geforce-now
+    state: "{{ geforcenow_state }}"
+    install_args: "{{ chocolatey_install_args }}"


### PR DESCRIPTION
## Summary
- add role to install NVIDIA GeForce Now via Chocolatey
- include new role in the Windows playbook
- document GeForce Now support in README

## Testing
- `./scripts/run-lint.sh` *(fails: yamllint is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684207fb7ae48322a10928a84cc5a265