### PR TITLE
Add pCloud and 7-Zip Chocolatey roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Orchestration Oasis
 
 Orchestration Oasis is an infrastructure automation project built around **Ansible**. It currently features roles for Docker, UFW, Fail2ban, pCloud, and Semaphore to help configure a Debian 12 server.
-Windows hosts can also be provisioned using Chocolatey, with roles to install VLC, Google Chrome, Thunderbird, Notepad++, and Git.
+Windows hosts can also be provisioned using Chocolatey, with roles to install VLC, Google Chrome, Thunderbird, Notepad++, Git, 7-Zip, and pCloud.
 The list below tracks the remaining work before the first stable release.
 
 ## Setup
@@ -25,7 +25,7 @@ ansible-playbook -i <inventory> site.yml
 ```
 
 For Windows hosts, you can install Chocolatey along with VLC, Google Chrome,
-Thunderbird, Notepad++, and Git in one step:
+Thunderbird, Notepad++, Git, 7-Zip, and pCloud in one step:
 
 ```bash
 ansible-playbook -i <inventory> playbooks/install_chocolatey_and_vlc.yml

--- a/ansible/playbooks/install_chocolatey_and_vlc.yml
+++ b/ansible/playbooks/install_chocolatey_and_vlc.yml
@@ -8,3 +8,5 @@
     - thunderbird
     - notepadplusplus
     - git
+    - sevenzip
+    - pcloud_win

--- a/ansible/playbooks/roles/pcloud_win/defaults/main.yml
+++ b/ansible/playbooks/roles/pcloud_win/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+pcloud_win_state: "present"

--- a/ansible/playbooks/roles/pcloud_win/readme.md
+++ b/ansible/playbooks/roles/pcloud_win/readme.md
@@ -1,0 +1,7 @@
+# pCloud (Windows) Role
+
+Installs [pCloud](https://www.pcloud.com/) on Windows hosts using the `win_chocolatey` module from the `chocolatey.chocolatey` collection.
+
+## Variables
+
+- `pcloud_win_state`: Installation state for pCloud (`present` or `absent`). Defaults to `present`.

--- a/ansible/playbooks/roles/pcloud_win/tasks/main.yml
+++ b/ansible/playbooks/roles/pcloud_win/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Ensure pCloud is installed
+  chocolatey.chocolatey.win_chocolatey:
+    name: pcloud
+    state: "{{ pcloud_win_state }}"
+    install_args: "{{ chocolatey_install_args }}"

--- a/ansible/playbooks/roles/sevenzip/defaults/main.yml
+++ b/ansible/playbooks/roles/sevenzip/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+sevenzip_state: "present"

--- a/ansible/playbooks/roles/sevenzip/readme.md
+++ b/ansible/playbooks/roles/sevenzip/readme.md
@@ -1,0 +1,7 @@
+# 7-Zip Role
+
+Installs [7-Zip](https://www.7-zip.org/) on Windows hosts using the `win_chocolatey` module from the `chocolatey.chocolatey` collection.
+
+## Variables
+
+- `sevenzip_state`: Installation state for 7-Zip (`present` or `absent`). Defaults to `present`.

--- a/ansible/playbooks/roles/sevenzip/tasks/main.yml
+++ b/ansible/playbooks/roles/sevenzip/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Ensure 7-Zip is installed
+  chocolatey.chocolatey.win_chocolatey:
+    name: 7zip.install
+    state: "{{ sevenzip_state }}"
+    install_args: "{{ chocolatey_install_args }}"


### PR DESCRIPTION
## Summary
- add pCloud and 7-Zip roles for Windows via Chocolatey
- install the new roles in the Chocolatey playbook
- document the new packages in README

## Testing
- `./scripts/run-lint.sh` *(fails: yamllint is not installed, ansible-lint is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842e7cede6c832288d9cedc0a814039