### PR TITLE
Add ZeroTier and Signal Chocolatey roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Orchestration Oasis
 
 Orchestration Oasis is an infrastructure automation project built around **Ansible**. It currently features roles for Docker, UFW, Fail2ban, pCloud, and Semaphore to help configure a Debian 12 server.
-Windows hosts can also be provisioned using Chocolatey, with roles to install VLC, Google Chrome, Thunderbird, Notepad++, Git, 7-Zip, and pCloud.
+Windows hosts can also be provisioned using Chocolatey, with roles to install VLC, Google Chrome, Thunderbird, Notepad++, Git, 7-Zip, pCloud, Signal, and ZeroTier.
 The list below tracks the remaining work before the first stable release.
 
 ## Setup
@@ -25,7 +25,7 @@ ansible-playbook -i <inventory> site.yml
 ```
 
 For Windows hosts, you can install Chocolatey along with VLC, Google Chrome,
-Thunderbird, Notepad++, Git, 7-Zip, and pCloud in one step:
+Thunderbird, Notepad++, Git, 7-Zip, pCloud, Signal, and ZeroTier in one step:
 
 ```bash
 ansible-playbook -i <inventory> playbooks/install_chocolatey_and_vlc.yml

--- a/ansible/playbooks/install_chocolatey_and_vlc.yml
+++ b/ansible/playbooks/install_chocolatey_and_vlc.yml
@@ -10,3 +10,5 @@
     - git
     - sevenzip
     - pcloud_win
+    - zerotier
+    - signal

--- a/ansible/playbooks/roles/signal/defaults/main.yml
+++ b/ansible/playbooks/roles/signal/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+signal_state: "present"

--- a/ansible/playbooks/roles/signal/readme.md
+++ b/ansible/playbooks/roles/signal/readme.md
@@ -1,0 +1,7 @@
+# Signal Role
+
+Installs [Signal Desktop](https://signal.org/) on Windows hosts using the `win_chocolatey` module from the `chocolatey.chocolatey` collection.
+
+## Variables
+
+- `signal_state`: Installation state for Signal (`present` or `absent`). Defaults to `present`.

--- a/ansible/playbooks/roles/signal/tasks/main.yml
+++ b/ansible/playbooks/roles/signal/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Ensure Signal is installed
+  chocolatey.chocolatey.win_chocolatey:
+    name: signal
+    state: "{{ signal_state }}"
+    install_args: "{{ chocolatey_install_args }}"

--- a/ansible/playbooks/roles/zerotier/defaults/main.yml
+++ b/ansible/playbooks/roles/zerotier/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+zerotier_state: "present"

--- a/ansible/playbooks/roles/zerotier/readme.md
+++ b/ansible/playbooks/roles/zerotier/readme.md
@@ -1,0 +1,7 @@
+# ZeroTier Role
+
+Installs [ZeroTier](https://www.zerotier.com/) on Windows hosts using the `win_chocolatey` module from the `chocolatey.chocolatey` collection.
+
+## Variables
+
+- `zerotier_state`: Installation state for ZeroTier (`present` or `absent`). Defaults to `present`.

--- a/ansible/playbooks/roles/zerotier/tasks/main.yml
+++ b/ansible/playbooks/roles/zerotier/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Ensure ZeroTier is installed
+  chocolatey.chocolatey.win_chocolatey:
+    name: zerotier-one
+    state: "{{ zerotier_state }}"
+    install_args: "{{ chocolatey_install_args }}"


### PR DESCRIPTION
## Summary
- add ZeroTier and Signal roles for Windows hosts
- include the new roles in the Chocolatey playbook
- document the additions in the README

## Testing
- `./scripts/run-lint.sh` *(fails: yamllint and ansible-lint not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842eae304288322ace4271315d3c89a