### PR TITLE
Add Everything package to Chocolatey setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Orchestration Oasis
 
 Orchestration Oasis is an infrastructure automation project built around **Ansible**. It currently features roles for Docker, UFW, Fail2ban, pCloud, and Semaphore to help configure a Debian 12 server.
-Windows hosts can also be provisioned using Chocolatey, with roles to install VLC, Google Chrome, Thunderbird, Notepad++, Git, 7-Zip, pCloud, Signal, and ZeroTier.
+Windows hosts can also be provisioned using Chocolatey, with roles to install VLC, Google Chrome, Thunderbird, Notepad++, Git, 7-Zip, Everything, pCloud, Signal, and ZeroTier.
 The list below tracks the remaining work before the first stable release.
 
 ## Setup
@@ -25,7 +25,7 @@ ansible-playbook -i <inventory> site.yml
 ```
 
 For Windows hosts, you can install Chocolatey along with VLC, Google Chrome,
-Thunderbird, Notepad++, Git, 7-Zip, pCloud, Signal, and ZeroTier in one step:
+Thunderbird, Notepad++, Git, 7-Zip, Everything, pCloud, Signal, and ZeroTier in one step:
 
 ```bash
 ansible-playbook -i <inventory> playbooks/install_chocolatey_and_vlc.yml

--- a/ansible/playbooks/install_chocolatey_and_vlc.yml
+++ b/ansible/playbooks/install_chocolatey_and_vlc.yml
@@ -9,6 +9,7 @@
     - notepadplusplus
     - git
     - sevenzip
+    - everything
     - pcloud_win
     - zerotier
     - signal

--- a/ansible/playbooks/roles/everything/defaults/main.yml
+++ b/ansible/playbooks/roles/everything/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+everything_state: "present"

--- a/ansible/playbooks/roles/everything/tasks/main.yml
+++ b/ansible/playbooks/roles/everything/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Ensure Everything is installed
+  chocolatey.chocolatey.win_chocolatey:
+    name: everything
+    state: "{{ everything_state }}"
+    install_args: "{{ chocolatey_install_args }}"


### PR DESCRIPTION
## Summary
- install voidtools Everything via Chocolatey
- include new role in combined Windows playbook
- document Everything in README

## Testing
- `./scripts/run-lint.sh` *(fails: yamllint is not installed, ansible-lint is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842ef1bcffc832291f704537fa42f38