### PR TITLE
Add LibreOffice chocolatey role and restore install args

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Orchestration Oasis
 
 Orchestration Oasis is an infrastructure automation project built around **Ansible**. It currently features roles for Docker, UFW, Fail2ban, pCloud, and Semaphore to help configure a Debian 12 server.
-Windows hosts can also be provisioned using Chocolatey, with roles to install VLC, Google Chrome, Thunderbird, Notepad++, Git, 7-Zip, Everything, pCloud, Signal, and ZeroTier.
+Windows hosts can also be provisioned using Chocolatey, with roles to install VLC, Google Chrome, Thunderbird, Notepad++, Git, 7-Zip, Everything, LibreOffice, pCloud, Signal, and ZeroTier.
 The list below tracks the remaining work before the first stable release.
 
 ## Setup
@@ -25,7 +25,7 @@ ansible-playbook -i <inventory> site.yml
 ```
 
 For Windows hosts, you can install Chocolatey along with VLC, Google Chrome,
-Thunderbird, Notepad++, Git, 7-Zip, Everything, pCloud, Signal, and ZeroTier in one step:
+Thunderbird, Notepad++, Git, 7-Zip, Everything, LibreOffice, pCloud, Signal, and ZeroTier in one step:
 
 ```bash
 ansible-playbook -i <inventory> playbooks/install_chocolatey_and_vlc.yml

--- a/ansible/playbooks/install_chocolatey_and_vlc.yml
+++ b/ansible/playbooks/install_chocolatey_and_vlc.yml
@@ -10,6 +10,7 @@
     - git
     - sevenzip
     - everything
+    - libreoffice
     - pcloud_win
     - zerotier
     - signal

--- a/ansible/playbooks/roles/chocolatey/defaults/main.yml
+++ b/ansible/playbooks/roles/chocolatey/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 chocolatey_state: "present"
-chocolatey_install_args: ""
+chocolatey_install_args: "ALLUSERS=1"

--- a/ansible/playbooks/roles/chocolatey/readme.md
+++ b/ansible/playbooks/roles/chocolatey/readme.md
@@ -8,3 +8,4 @@ versions.
 ## Variables
 
 - `chocolatey_state`: Installation state for Chocolatey (`present` or `absent`). Defaults to `present`.
+- `chocolatey_install_args`: Arguments passed to all Chocolatey package installs. Defaults to `ALLUSERS=1`.

--- a/ansible/playbooks/roles/libreoffice/defaults/main.yml
+++ b/ansible/playbooks/roles/libreoffice/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+libreoffice_state: "present"

--- a/ansible/playbooks/roles/libreoffice/tasks/main.yml
+++ b/ansible/playbooks/roles/libreoffice/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Ensure LibreOffice is installed
+  chocolatey.chocolatey.win_chocolatey:
+    name: libreoffice-fresh
+    state: "{{ libreoffice_state }}"
+    install_args: "{{ chocolatey_install_args }}"


### PR DESCRIPTION
## Summary
- restore `ALLUSERS=1` default Chocolatey install args
- document install args variable
- add LibreOffice Chocolatey role
- include LibreOffice in the full Windows install playbook
- update docs for new package

## Testing
- `./scripts/run-lint.sh` *(fails: couldn't resolve chocolatey.chocolatey.win_chocolatey)*

------
https://chatgpt.com/codex/tasks/task_e_6842f8cdd41c8322a65cd14196b8b124