### PR TITLE
Add Steam package for Chocolatey

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Orchestration Oasis
 
 Orchestration Oasis is an infrastructure automation project built around **Ansible**. It currently features roles for Docker, UFW, Fail2ban, pCloud, and Semaphore to help configure a Debian 12 server.
-Windows hosts can also be provisioned using Chocolatey, with roles to install VLC, Google Chrome, Thunderbird, Notepad++, Git, 7-Zip, Everything, LibreOffice, pCloud, Signal, and ZeroTier.
+Windows hosts can also be provisioned using Chocolatey, with roles to install VLC, Google Chrome, Thunderbird, Notepad++, Git, 7-Zip, Everything, LibreOffice, pCloud, Signal, ZeroTier, and Steam.
 The list below tracks the remaining work before the first stable release.
 
 ## Setup
@@ -25,7 +25,7 @@ ansible-playbook -i <inventory> site.yml
 ```
 
 For Windows hosts, you can install Chocolatey along with VLC, Google Chrome,
-Thunderbird, Notepad++, Git, 7-Zip, Everything, LibreOffice, pCloud, Signal, and ZeroTier in one step:
+Thunderbird, Notepad++, Git, 7-Zip, Everything, LibreOffice, pCloud, Signal, ZeroTier, and Steam in one step:
 
 ```bash
 ansible-playbook -i <inventory> playbooks/install_chocolatey_and_vlc.yml

--- a/ansible/playbooks/install_chocolatey_and_vlc.yml
+++ b/ansible/playbooks/install_chocolatey_and_vlc.yml
@@ -14,3 +14,4 @@
     - pcloud_win
     - zerotier
     - signal
+    - steam

--- a/ansible/playbooks/roles/steam/defaults/main.yml
+++ b/ansible/playbooks/roles/steam/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+steam_state: "present"

--- a/ansible/playbooks/roles/steam/readme.md
+++ b/ansible/playbooks/roles/steam/readme.md
@@ -1,0 +1,7 @@
+# Steam Role
+
+Installs [Steam](https://store.steampowered.com/) on Windows hosts using the `win_chocolatey` module from the `chocolatey.chocolatey` collection.
+
+## Variables
+
+- `steam_state`: Installation state for Steam (`present` or `absent`). Defaults to `present`.

--- a/ansible/playbooks/roles/steam/tasks/main.yml
+++ b/ansible/playbooks/roles/steam/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Ensure Steam is installed
+  chocolatey.chocolatey.win_chocolatey:
+    name: steam
+    state: "{{ steam_state }}"
+    install_args: "{{ chocolatey_install_args }}"


### PR DESCRIPTION
## Summary
- install Steam on Windows via a new Chocolatey role
- include the new role in the combined playbook
- mention Steam in the README

## Testing
- `./scripts/run-lint.sh` *(fails: yamllint and ansible-lint not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849b7c4f2c88322a7e015595d0a64b9