### PR TITLE
Add NetBox role

### DIFF
--- a/ansible/playbooks/install_netbox.yml
+++ b/ansible/playbooks/install_netbox.yml
@@ -1,0 +1,6 @@
+---
+- name: Install and configure NetBox
+  hosts: netbox
+  become: true
+  roles:
+    - netbox

--- a/ansible/playbooks/roles/netbox/defaults/main.yml
+++ b/ansible/playbooks/roles/netbox/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+netbox_version: "latest"
+netbox_dir: "/opt/netbox"
+netbox_db_name: "netbox"
+netbox_db_user: "netbox"
+netbox_db_password: "netbox"
+netbox_redis_password: "netbox"
+netbox_secret_key: "change-me"

--- a/ansible/playbooks/roles/netbox/readme.md
+++ b/ansible/playbooks/roles/netbox/readme.md
@@ -1,0 +1,15 @@
+# NetBox Role
+
+Deploys [NetBox](https://github.com/netbox-community/netbox) using Docker Compose.
+
+## Variables
+
+- `netbox_version`: Docker image tag (default `latest`)
+- `netbox_dir`: Directory for the compose file (default `/opt/netbox`)
+- `netbox_db_user`: Database user (default `netbox`)
+- `netbox_db_name`: Database name (default `netbox`)
+- `netbox_db_password`: Database password (default `netbox`)
+- `netbox_redis_password`: Redis password (default `netbox`)
+- `netbox_secret_key`: Django secret key (default `change-me`)
+
+Store sensitive values outside of version control if required.

--- a/ansible/playbooks/roles/netbox/tasks/main.yml
+++ b/ansible/playbooks/roles/netbox/tasks/main.yml
@@ -1,0 +1,34 @@
+---
+- name: Ensure NetBox directory exists
+  ansible.builtin.file:
+    path: "{{ netbox_dir }}"
+    state: directory
+    mode: '0755'
+
+- name: Deploy environment files
+  ansible.builtin.template:
+    src: "{{ item.src }}"
+    dest: "{{ netbox_dir }}/{{ item.dest }}"
+    mode: '0600'
+  loop:
+    - { src: 'netbox.env.j2', dest: 'netbox.env' }
+    - { src: 'postgres.env.j2', dest: 'postgres.env' }
+    - { src: 'redis.env.j2', dest: 'redis.env' }
+  loop_control:
+    label: "{{ item.dest }}"
+
+- name: Deploy docker-compose file
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
+    dest: "{{ netbox_dir }}/docker-compose.yml"
+    mode: '0644'
+
+- name: Launch NetBox stack
+  community.docker.docker_compose_v2:
+    project_src: "{{ netbox_dir }}"
+    state: present
+  register: netbox_compose
+
+- name: Display compose status
+  ansible.builtin.debug:
+    var: netbox_compose

--- a/ansible/playbooks/roles/netbox/templates/docker-compose.yml.j2
+++ b/ansible/playbooks/roles/netbox/templates/docker-compose.yml.j2
@@ -1,0 +1,33 @@
+version: '3'
+services:
+  postgres:
+    image: postgres:15-alpine
+    restart: unless-stopped
+    env_file:
+      - postgres.env
+    volumes:
+      - db:/var/lib/postgresql/data
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: redis-server --appendonly yes
+    env_file:
+      - redis.env
+    volumes:
+      - redis:/data
+  netbox:
+    image: netboxcommunity/netbox:{{ netbox_version }}
+    depends_on:
+      - postgres
+      - redis
+    env_file:
+      - netbox.env
+    ports:
+      - "8080:8080"
+    volumes:
+      - netbox-media:/opt/netbox/netbox/media
+    restart: unless-stopped
+volumes:
+  db:
+  redis:
+  netbox-media:

--- a/ansible/playbooks/roles/netbox/templates/netbox.env.j2
+++ b/ansible/playbooks/roles/netbox/templates/netbox.env.j2
@@ -1,0 +1,8 @@
+ALLOWED_HOSTS=*
+DB_HOST=postgres
+DB_NAME={{ netbox_db_name }}
+DB_USER={{ netbox_db_user }}
+DB_PASSWORD={{ netbox_db_password }}
+REDIS_HOST=redis
+REDIS_PASSWORD={{ netbox_redis_password }}
+SECRET_KEY={{ netbox_secret_key }}

--- a/ansible/playbooks/roles/netbox/templates/postgres.env.j2
+++ b/ansible/playbooks/roles/netbox/templates/postgres.env.j2
@@ -1,0 +1,3 @@
+POSTGRES_DB={{ netbox_db_name }}
+POSTGRES_USER={{ netbox_db_user }}
+POSTGRES_PASSWORD={{ netbox_db_password }}

--- a/ansible/playbooks/roles/netbox/templates/redis.env.j2
+++ b/ansible/playbooks/roles/netbox/templates/redis.env.j2
@@ -1,0 +1,1 @@
+REDIS_PASSWORD={{ netbox_redis_password }}


### PR DESCRIPTION
## Summary
- add a NetBox role with Docker Compose support
- provide defaults and templates for NetBox
- document the NetBox role
- add a playbook to install NetBox

## Testing
- `./scripts/run-lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_6849be63a9c48322916ad8c8ba407b66