### PR TITLE
Add javaruntime role

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Orchestration Oasis
 
 Orchestration Oasis is an infrastructure automation project built around **Ansible**. It currently features roles for Docker, UFW, Fail2ban, pCloud, and Semaphore to help configure a Debian 12 server.
-Windows hosts can also be provisioned using Chocolatey, with roles to install VLC, Google Chrome, Thunderbird, Notepad++, Git, 7-Zip, Everything, LibreOffice, pCloud, Signal, ZeroTier, and Steam.
+Windows hosts can also be provisioned using Chocolatey, with roles to install VLC, Google Chrome, Thunderbird, Notepad++, Git, Java Runtime Environment (JRE), 7-Zip, Everything, LibreOffice, pCloud, Signal, ZeroTier, and Steam.
 The list below tracks the remaining work before the first stable release.
 
 ## Setup
@@ -25,7 +25,7 @@ ansible-playbook -i <inventory> site.yml
 ```
 
 For Windows hosts, you can install Chocolatey along with VLC, Google Chrome,
-Thunderbird, Notepad++, Git, 7-Zip, Everything, LibreOffice, pCloud, Signal, ZeroTier, and Steam in one step:
+Thunderbird, Notepad++, Git, Java Runtime Environment (JRE), 7-Zip, Everything, LibreOffice, pCloud, Signal, ZeroTier, and Steam in one step:
 
 ```bash
 ansible-playbook -i <inventory> playbooks/install_chocolatey_and_vlc.yml

--- a/ansible/playbooks/install_chocolatey_and_vlc.yml
+++ b/ansible/playbooks/install_chocolatey_and_vlc.yml
@@ -8,6 +8,7 @@
     - thunderbird
     - notepadplusplus
     - git
+    - javaruntime
     - sevenzip
     - everything
     - libreoffice

--- a/ansible/playbooks/roles/javaruntime/defaults/main.yml
+++ b/ansible/playbooks/roles/javaruntime/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+javaruntime_state: "present"

--- a/ansible/playbooks/roles/javaruntime/tasks/main.yml
+++ b/ansible/playbooks/roles/javaruntime/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Ensure Java Runtime Environment is installed
+  chocolatey.chocolatey.win_chocolatey:
+    name: javaruntime
+    state: "{{ javaruntime_state }}"
+    install_args: "{{ chocolatey_install_args }}"


### PR DESCRIPTION
## Summary
- add a javaruntime role for Chocolatey
- install the JRE role in the Windows desktop playbook
- update README with the new package

## Testing
- `scripts/run-lint.sh` *(fails: yamllint and ansible-lint not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849e8e2872c8322b4ac9bbd751c6e90