### PR TITLE
Use openjdk17 for Windows Java runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Orchestration Oasis
 
 Orchestration Oasis is an infrastructure automation project built around **Ansible**. It currently features roles for Docker, UFW, Fail2ban, pCloud, and Semaphore to help configure a Debian 12 server.
-Windows hosts can also be provisioned using Chocolatey, with roles to install VLC, Google Chrome, Thunderbird, Notepad++, Git, Java Runtime Environment (JRE), 7-Zip, Everything, LibreOffice, pCloud, Signal, ZeroTier, and Steam.
+Windows hosts can also be provisioned using Chocolatey, with roles to install VLC, Google Chrome, Thunderbird, Notepad++, Git, OpenJDK 17 (JRE), 7-Zip, Everything, LibreOffice, pCloud, Signal, ZeroTier, and Steam.
 The list below tracks the remaining work before the first stable release.
 
 ## Setup
@@ -25,7 +25,7 @@ ansible-playbook -i <inventory> site.yml
 ```
 
 For Windows hosts, you can install Chocolatey along with VLC, Google Chrome,
-Thunderbird, Notepad++, Git, Java Runtime Environment (JRE), 7-Zip, Everything, LibreOffice, pCloud, Signal, ZeroTier, and Steam in one step:
+Thunderbird, Notepad++, Git, OpenJDK 17 (JRE), 7-Zip, Everything, LibreOffice, pCloud, Signal, ZeroTier, and Steam in one step:
 
 ```bash
 ansible-playbook -i <inventory> playbooks/install_chocolatey_and_vlc.yml

--- a/ansible/playbooks/roles/javaruntime/tasks/main.yml
+++ b/ansible/playbooks/roles/javaruntime/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
-- name: Ensure Java Runtime Environment is installed
+- name: Ensure OpenJDK 17 is installed
   chocolatey.chocolatey.win_chocolatey:
-    name: javaruntime
+    name: openjdk17
     state: "{{ javaruntime_state }}"
     install_args: "{{ chocolatey_install_args }}"


### PR DESCRIPTION
## Summary
- swap `javaruntime` Chocolatey package for `openjdk17`
- mention OpenJDK 17 in the README

## Testing
- `scripts/run-lint.sh` *(fails: yamllint and ansible-lint not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849ee8ed68c83228d9967d588cc321a