### PR TITLE
Fix tesseract.js example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ The playbooks `install_chocolatey.yml` and `install_vlc.yml` remain available if
 The Chocolatey role now also upgrades all installed packages to their latest
 versions on each run.
 
+## OCR Example
+
+An example Node script using **tesseract.js** is available in `examples/ocr.mjs`.
+Install `tesseract.js` and run the script with an image path:
+
+```bash
+npm install tesseract.js@latest
+node examples/ocr.mjs path/to/image.png
+```
+
 ## Linting
 
 Use the helper script to run `yamllint` and `ansible-lint` locally:

--- a/examples/ocr.mjs
+++ b/examples/ocr.mjs
@@ -1,0 +1,24 @@
+import { createWorker } from 'tesseract.js';
+
+async function main() {
+  if (process.argv.length < 3) {
+    console.error('Usage: node examples/ocr.mjs <image>');
+    process.exit(1);
+  }
+
+  const imagePath = process.argv[2];
+  const worker = await createWorker('eng');
+
+  try {
+    const {
+      data: { text },
+    } = await worker.recognize(imagePath);
+    console.log(text);
+  } catch (err) {
+    console.error('OCR error:', err);
+  } finally {
+    await worker.terminate();
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- update README usage instructions
- fix OCR script for tesseract.js v6 and save as `ocr.mjs`

## Testing
- `./scripts/run-lint.sh` *(fails: yamllint is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684b005004e083229b6ca654a82b3706