### PR TITLE
Add Zerotier role

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Orchestration Oasis
 
-Orchestration Oasis is an infrastructure automation project built around **Ansible**. It currently features roles for Docker, UFW, Fail2ban, pCloud, and Semaphore to help configure a Debian 12 server.
+Orchestration Oasis is an infrastructure automation project built around **Ansible**. It currently features roles for Docker, UFW, Fail2ban, pCloud, Semaphore, and Zerotier to help configure a Debian 12 server.
 Windows hosts can also be provisioned using Chocolatey. A dedicated role installs Chocolatey, and another role installs the optional Chocolatey GUI.
 The list below tracks the remaining work before the first stable release.
 
@@ -39,6 +39,14 @@ ansible-playbook -i <inventory> playbooks/install_chocolatey_gui.yml
 
 The Chocolatey role now also upgrades all installed packages to their latest
 versions on each run.
+
+To install Zerotier only on hosts in the `zerotier` group:
+
+```bash
+ansible-playbook -i <inventory> playbooks/install_zerotier.yml
+```
+
+Set `zerotier_network_id` to join a specific network (leave empty to skip).
 
 To remove unnecessary packages while keeping Chocolatey, run `choco uninstall <package>` for each application you want to remove.
 

--- a/ansible/playbooks/install_zerotier.yml
+++ b/ansible/playbooks/install_zerotier.yml
@@ -1,0 +1,7 @@
+---
+- name: Install and configure Zerotier
+  hosts: zerotier
+  become: true
+  roles:
+    - zerotier
+

--- a/ansible/playbooks/roles/zerotier/defaults/main.yml
+++ b/ansible/playbooks/roles/zerotier/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+zerotier_network_id: ""
+

--- a/ansible/playbooks/roles/zerotier/readme.md
+++ b/ansible/playbooks/roles/zerotier/readme.md
@@ -1,0 +1,15 @@
+# Zerotier Role
+
+Installs [ZeroTier](https://www.zerotier.com/) on Linux systems and optionally joins a network.
+
+Example inventory entry:
+
+```yaml
+[zerotier]
+host1 zerotier_network_id=abcd1234
+```
+
+## Variables
+
+- `zerotier_network_id`: Network ID to join (default `""`). If empty, no network is joined.
+

--- a/ansible/playbooks/roles/zerotier/tasks/main.yml
+++ b/ansible/playbooks/roles/zerotier/tasks/main.yml
@@ -1,0 +1,37 @@
+---
+- name: Add Zerotier GPG key
+  ansible.builtin.apt_key:
+    url: https://download.zerotier.com/contact%40zerotier.com.gpg
+    state: present
+  become: true
+
+- name: Add Zerotier repository
+  ansible.builtin.apt_repository:
+    repo: "deb https://download.zerotier.com/debian/{{ ansible_distribution_release | lower }} {{ ansible_distribution_release | lower }} main"
+    filename: zerotier
+    state: present
+    update_cache: true
+  become: true
+
+- name: Install zerotier-one package
+  ansible.builtin.apt:
+    name: zerotier-one
+    state: present
+    update_cache: true
+  become: true
+
+- name: Enable and start Zerotier service
+  ansible.builtin.systemd:
+    name: zerotier-one
+    enabled: true
+    state: started
+  become: true
+
+- name: Join Zerotier network if configured
+  ansible.builtin.command: "zerotier-cli join {{ zerotier_network_id }}"
+  args:
+    creates: "/var/lib/zerotier-one/networks.d/{{ zerotier_network_id }}.conf"
+  when: zerotier_network_id | length > 0
+  become: true
+  changed_when: false
+

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -8,3 +8,4 @@
     - fail2ban
     - pcloud
     - semaphore
+    - zerotier


### PR DESCRIPTION
## Summary
- add new Ansible role to install Zerotier
- document using `install_zerotier.yml` playbook
- show example inventory usage
- ensure tasks run with elevated privileges and are idempotent

## Testing
- `./scripts/run-lint.sh` *(fails: yamllint and ansible-lint not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68656fe3f87c83229cd74538e71a0608