### PR TITLE
Remove Ansible install from setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ The list below tracks the remaining work before the first stable release.
 
 ## Setup
 
-Run the helper script to install Docker and Ansible on a fresh Debian system.
-The script is non-interactive, installs Git and optionally clones a repository
-if a URL is provided. It skips packages that are already installed:
+Run the helper script to install Docker on a fresh Debian system. Ansible is
+included with the Semaphore container, so it does not need to be installed on
+the host. The script is non-interactive, installs Git and optionally clones a
+repository if a URL is provided. It skips packages that are already installed:
 
 ```bash
 ./scripts/setup-debian.sh <repo_url>

--- a/scripts/setup-debian.sh
+++ b/scripts/setup-debian.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Install Docker and Ansible on Debian-based systems
+# Install Docker on Debian-based systems
 set -euo pipefail
 
 # Optional repository URL to clone
@@ -17,12 +17,6 @@ $SUDO apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-rele
 if [ -n "$REPO_URL" ]; then
     git clone "$REPO_URL"
 fi
-
-# Install Ansible if not present
-if ! command -v ansible >/dev/null 2>&1; then
-    $SUDO apt-get install -y ansible
-fi
-
 
 # Install Docker if not present
 if ! command -v docker >/dev/null 2>&1; then
@@ -46,4 +40,5 @@ if ! command -v docker >/dev/null 2>&1; then
     fi
 fi
 
-echo "Docker and Ansible installation complete."
+echo "Docker installation complete."
+


### PR DESCRIPTION
## Summary
- update `setup-debian.sh` so it only installs Docker
- document that Ansible comes with Semaphore and isn't installed by the helper script

## Testing
- `scripts/run-lint.sh` *(fails: yamllint and ansible-lint not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686575696540832284dbdc50cc694203