### PR TITLE
Use Docker Compose for Zerotier role

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Orchestration Oasis
 
-Orchestration Oasis is an infrastructure automation project built around **Ansible**. It currently features roles for Docker, UFW, Fail2ban, pCloud, Semaphore, and Zerotier to help configure a Debian 12 server.
+Orchestration Oasis is an infrastructure automation project built around **Ansible**. It currently features roles for Docker, UFW, Fail2ban, pCloud, Semaphore, and Zerotier (using Docker Compose) to help configure a Debian 12 server.
 Windows hosts can also be provisioned using Chocolatey. A dedicated role installs Chocolatey, and another role installs the optional Chocolatey GUI.
 The list below tracks the remaining work before the first stable release.
 

--- a/ansible/playbooks/roles/zerotier/defaults/main.yml
+++ b/ansible/playbooks/roles/zerotier/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
+zerotier_version: "latest"
+zerotier_dir: "/opt/zerotier"
 zerotier_network_id: ""
-

--- a/ansible/playbooks/roles/zerotier/readme.md
+++ b/ansible/playbooks/roles/zerotier/readme.md
@@ -1,6 +1,6 @@
 # Zerotier Role
 
-Installs [ZeroTier](https://www.zerotier.com/) on Linux systems and optionally joins a network.
+Deploys [ZeroTier](https://www.zerotier.com/) using Docker Compose and optionally joins a network.
 
 Example inventory entry:
 
@@ -11,5 +11,6 @@ host1 zerotier_network_id=abcd1234
 
 ## Variables
 
+- `zerotier_version`: Image tag to use (default `"latest"`).
+- `zerotier_dir`: Directory for the compose project (default `/opt/zerotier`).
 - `zerotier_network_id`: Network ID to join (default `""`). If empty, no network is joined.
-

--- a/ansible/playbooks/roles/zerotier/tasks/main.yml
+++ b/ansible/playbooks/roles/zerotier/tasks/main.yml
@@ -1,37 +1,22 @@
 ---
-- name: Add Zerotier GPG key
-  ansible.builtin.apt_key:
-    url: https://download.zerotier.com/contact%40zerotier.com.gpg
+- name: Ensure Zerotier directory exists
+  ansible.builtin.file:
+    path: "{{ zerotier_dir }}"
+    state: directory
+    mode: '0755'
+
+- name: Deploy docker-compose file
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
+    dest: "{{ zerotier_dir }}/docker-compose.yml"
+    mode: '0644'
+
+- name: Launch Zerotier stack
+  community.docker.docker_compose_v2:
+    project_src: "{{ zerotier_dir }}"
     state: present
-  become: true
+  register: zerotier_compose
 
-- name: Add Zerotier repository
-  ansible.builtin.apt_repository:
-    repo: "deb https://download.zerotier.com/debian/{{ ansible_distribution_release | lower }} {{ ansible_distribution_release | lower }} main"
-    filename: zerotier
-    state: present
-    update_cache: true
-  become: true
-
-- name: Install zerotier-one package
-  ansible.builtin.apt:
-    name: zerotier-one
-    state: present
-    update_cache: true
-  become: true
-
-- name: Enable and start Zerotier service
-  ansible.builtin.systemd:
-    name: zerotier-one
-    enabled: true
-    state: started
-  become: true
-
-- name: Join Zerotier network if configured
-  ansible.builtin.command: "zerotier-cli join {{ zerotier_network_id }}"
-  args:
-    creates: "/var/lib/zerotier-one/networks.d/{{ zerotier_network_id }}.conf"
-  when: zerotier_network_id | length > 0
-  become: true
-  changed_when: false
-
+- name: Display compose status
+  ansible.builtin.debug:
+    var: zerotier_compose

--- a/ansible/playbooks/roles/zerotier/templates/docker-compose.yml.j2
+++ b/ansible/playbooks/roles/zerotier/templates/docker-compose.yml.j2
@@ -1,0 +1,17 @@
+version: '3'
+services:
+  zerotier:
+    image: zerotier/zerotier:{{ zerotier_version }}
+    restart: unless-stopped
+    network_mode: host
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - /dev/net/tun
+    volumes:
+      - zerotier-data:/var/lib/zerotier-one
+{% if zerotier_network_id %}
+    command: {{ zerotier_network_id }}
+{% endif %}
+volumes:
+  zerotier-data:


### PR DESCRIPTION
## Summary
- switch Zerotier role to Docker Compose
- add compose template and related defaults
- document Zerotier role variables
- note compose usage in project README

## Testing
- `./scripts/run-lint.sh` *(fails: yamllint is not installed, ansible-lint is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686576f8b6548322b676ea8da35a6170