### PR TITLE
Add Fail2ban setup to Debian helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ The list below tracks the remaining work before the first stable release.
 
 ## Setup
 
-Run the helper script to install Docker on a fresh Debian system. Ansible is
-included with the Semaphore container, so it does not need to be installed on
+Run the helper script to install Docker and Fail2ban on a fresh Debian system.
+Ansible is included with the Semaphore container, so it does not need to be installed on
 the host. The script is non-interactive, installs Git and optionally clones a
-repository if a URL is provided. It skips packages that are already installed:
+repository if a URL is provided. Docker and Fail2ban are configured with a basic setup and the script skips packages that are already installed:
 
 ```bash
 ./scripts/setup-debian.sh <repo_url>

--- a/scripts/setup-debian.sh
+++ b/scripts/setup-debian.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Install Docker on Debian-based systems
+# Install Docker and Fail2ban on Debian-based systems
 set -euo pipefail
 
 # Optional repository URL to clone
@@ -41,4 +41,25 @@ if ! command -v docker >/dev/null 2>&1; then
 fi
 
 echo "Docker installation complete."
+
+# Install Fail2ban if not present
+if ! dpkg -s fail2ban >/dev/null 2>&1; then
+    $SUDO apt-get install -y fail2ban
+fi
+
+# Basic Fail2ban configuration
+$SUDO tee /etc/fail2ban/jail.local >/dev/null <<'EOF'
+[DEFAULT]
+bantime = 3600
+findtime = 600
+maxretry = 5
+
+[sshd]
+enabled = true
+EOF
+
+# Enable Fail2ban service
+$SUDO systemctl enable --now fail2ban
+
+echo "Fail2ban installation complete."
 


### PR DESCRIPTION
## Summary
- extend `setup-debian.sh` to install Fail2ban and provide a simple `jail.local`
- mention Fail2ban in the README setup instructions

## Testing
- `./scripts/run-lint.sh` *(fails: yamllint and ansible-lint not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68658207993883228cf6a30454e32b6b