### PR TITLE
Add minimal fail2ban config to setup script

### DIFF
--- a/etc/fail2ban/fail2ban.conf
+++ b/etc/fail2ban/fail2ban.conf
@@ -1,0 +1,7 @@
+[DEFAULT]
+# Niveau de log (INFO par defaut)
+loglevel = INFO
+# Envoie les logs dans le journal systemd
+logtarget = SYSLOG
+# Utilise systemd/journald pour lire les journaux
+backend = systemd

--- a/etc/fail2ban/jail.local
+++ b/etc/fail2ban/jail.local
@@ -1,0 +1,13 @@
+[DEFAULT]
+# Utilise systemd comme backend pour toutes les jails
+backend = systemd
+# Temps de bannissement en secondes
+bantime = 3600
+# Nombre de tentatives avant bannissement
+maxretry = 5
+
+[sshd]
+# Jail pour proteger le service SSH
+enabled = true
+# Filtre standard sshd
+filter = sshd

--- a/scripts/setup-debian.sh
+++ b/scripts/setup-debian.sh
@@ -47,15 +47,24 @@ if ! dpkg -s fail2ban >/dev/null 2>&1; then
     $SUDO apt-get install -y fail2ban
 fi
 
-# Basic Fail2ban configuration
+
+# Minimal Fail2ban configuration
+$SUDO tee /etc/fail2ban/fail2ban.conf >/dev/null <<'EOF'
+[DEFAULT]
+loglevel = INFO
+logtarget = SYSLOG
+backend = systemd
+EOF
+
 $SUDO tee /etc/fail2ban/jail.local >/dev/null <<'EOF'
 [DEFAULT]
+backend = systemd
 bantime = 3600
-findtime = 600
 maxretry = 5
 
 [sshd]
 enabled = true
+filter = sshd
 EOF
 
 # Enable Fail2ban service


### PR DESCRIPTION
## Summary
- add systemd/journald backend to fail2ban config files
- generate these configs in `setup-debian.sh`

## Testing
- `./scripts/run-lint.sh` *(fails: yamllint and ansible-lint not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6865842a3b648322ba793d630d476333