### PR TITLE
Improve Fail2ban role

### DIFF
--- a/ansible/playbooks/roles/fail2ban/handlers/main.yml
+++ b/ansible/playbooks/roles/fail2ban/handlers/main.yml
@@ -1,0 +1,7 @@
+# ansible/playbooks/roles/fail2ban/handlers/main.yml
+---
+- name: Reload fail2ban
+  ansible.builtin.systemd:
+    name: fail2ban
+    state: reloaded
+  become: true

--- a/ansible/playbooks/roles/fail2ban/tasks/main.yml
+++ b/ansible/playbooks/roles/fail2ban/tasks/main.yml
@@ -1,9 +1,25 @@
+# ansible/playbooks/roles/fail2ban/tasks/main.yml
 ---
-- name: Install fail2ban package
+- name: Install fail2ban package via apt
   ansible.builtin.apt:
     name: fail2ban
     state: present
     update_cache: true
+  become: true
+
+- name: Check for sshd filter file
+  ansible.builtin.stat:
+    path: /etc/fail2ban/filter.d/sshd.conf
+  register: sshd_filter
+  become: true
+
+- name: Ensure sshd filter file exists with [Definition]
+  ansible.builtin.copy:
+    dest: /etc/fail2ban/filter.d/sshd.conf
+    content: "[Definition]\n"
+    mode: '0644'
+  when: not sshd_filter.stat.exists
+  notify: Reload fail2ban
   become: true
 
 - name: Deploy fail2ban configuration
@@ -11,10 +27,27 @@
     src: jail.local.j2
     dest: /etc/fail2ban/jail.local
     mode: '0644'
+  notify: Reload fail2ban
   become: true
 
-- name: Ensure fail2ban is enabled and running
-  ansible.builtin.service:
+- name: Clean fail2ban cache directory
+  ansible.builtin.file:
+    path: /var/lib/fail2ban
+    state: absent
+    recurse: true
+  become: true
+
+- name: Recreate fail2ban cache directory
+  ansible.builtin.file:
+    path: /var/lib/fail2ban
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+  become: true
+
+- name: Enable and start fail2ban service
+  ansible.builtin.systemd:
     name: fail2ban
     enabled: true
     state: started

--- a/ansible/playbooks/roles/fail2ban/templates/jail.local.j2
+++ b/ansible/playbooks/roles/fail2ban/templates/jail.local.j2
@@ -1,4 +1,6 @@
 # ansible/playbooks/roles/fail2ban/templates/jail.local.j2
+# Template for Fail2Ban configuration
+
 [DEFAULT]
 bantime = {{ fail2ban_bantime }}
 findtime = {{ fail2ban_findtime }}
@@ -6,3 +8,4 @@ maxretry = {{ fail2ban_maxretry }}
 
 [sshd]
 enabled = true
+filter = sshd


### PR DESCRIPTION
## Summary
- clean fail2ban cache before service start
- add handler to reload fail2ban
- expand tasks and add filter checks
- keep jail configuration templated

## Testing
- `ansible-lint ansible/playbooks/roles/fail2ban`

------
https://chatgpt.com/codex/tasks/task_e_68658e01e68c83229d400ee6ab95bb67