### PR TITLE
Add Dashy dashboard container role

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Orchestration Oasis
 
-Orchestration Oasis is an infrastructure automation project built around **Ansible**. It currently features roles for Docker, UFW, Fail2ban, pCloud, Semaphore, and Zerotier (using Docker Compose) to help configure a Debian 12 server.
+Orchestration Oasis is an infrastructure automation project built around **Ansible**. It currently features roles for Docker, UFW, Fail2ban, pCloud, Semaphore, and Zerotier, and a Dashy-based Dashboard (using Docker Compose) to help configure a Debian 12 server.
 Windows hosts can also be provisioned using Chocolatey. A dedicated role installs Chocolatey, and another role installs the optional Chocolatey GUI.
 The list below tracks the remaining work before the first stable release.
 

--- a/ansible/playbooks/install_dashboard.yml
+++ b/ansible/playbooks/install_dashboard.yml
@@ -1,0 +1,7 @@
+---
+- name: Install and configure Dashboard
+  hosts: dashboard
+  become: true
+  roles:
+    - dashboard
+

--- a/ansible/playbooks/roles/dashboard/defaults/main.yml
+++ b/ansible/playbooks/roles/dashboard/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+dashboard_version: "latest"
+dashboard_dir: "/opt/dashboard"
+dashboard_port: 4000

--- a/ansible/playbooks/roles/dashboard/readme.md
+++ b/ansible/playbooks/roles/dashboard/readme.md
@@ -1,0 +1,11 @@
+# Dashboard Role
+
+Deploys [Dashy](https://github.com/Lissy93/dashy) using Docker Compose.
+
+## Variables
+
+- `dashboard_version`: Docker image tag (default `latest`)
+- `dashboard_dir`: Directory for the compose file (default `/opt/dashboard`)
+- `dashboard_port`: Host port for Dashy UI (default `4000`)
+
+Store sensitive values outside of version control if required.

--- a/ansible/playbooks/roles/dashboard/tasks/main.yml
+++ b/ansible/playbooks/roles/dashboard/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+- name: Ensure Dashboard directory exists
+  ansible.builtin.file:
+    path: "{{ dashboard_dir }}"
+    state: directory
+    mode: '0755'
+
+- name: Deploy docker-compose file
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
+    dest: "{{ dashboard_dir }}/docker-compose.yml"
+    mode: '0644'
+
+- name: Launch Dashboard stack
+  community.docker.docker_compose_v2:
+    project_src: "{{ dashboard_dir }}"
+    state: present
+  register: dashboard_compose
+
+- name: Display compose status
+  ansible.builtin.debug:
+    var: dashboard_compose

--- a/ansible/playbooks/roles/dashboard/templates/docker-compose.yml.j2
+++ b/ansible/playbooks/roles/dashboard/templates/docker-compose.yml.j2
@@ -1,0 +1,11 @@
+version: '3'
+services:
+  dashboard:
+    image: lissy93/dashy:{{ dashboard_version }}
+    restart: unless-stopped
+    ports:
+      - "{{ dashboard_port }}:8080"
+    volumes:
+      - dashy-data:/app/user-data
+volumes:
+  dashy-data:


### PR DESCRIPTION
## Summary
- add a new `dashboard` role for Dashy dashboard
- include an install playbook
- update README with a mention of the new role

## Testing
- `bash scripts/run-lint.sh` *(fails: yamllint and ansible-lint not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6867010b81b08322903cc2e743a42bc9