### PR TITLE
Add DOCKER-USER integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ Set `zerotier_network_id` to join a specific network (leave empty to skip).
 
 To remove unnecessary packages while keeping Chocolatey, run `choco uninstall <package>` for each application you want to remove.
 
+To block ports exposed by Docker containers while keeping Docker's network stack
+active, define ports in `ufw_docker_blocked_ports`. The UFW role will insert
+rules into the `DOCKER-USER` chain:
+
+```yaml
+ufw_docker_blocked_ports:
+  - "4000"
+```
+
 
 ## Linting
 

--- a/ansible/playbooks/roles/ufw/defaults/main.yml
+++ b/ansible/playbooks/roles/ufw/defaults/main.yml
@@ -2,3 +2,6 @@
 ufw_allowed_ports:
   - "80"
   - "443"
+
+# List of Docker-exposed host ports to block via the DOCKER-USER chain
+ufw_docker_blocked_ports: []

--- a/ansible/playbooks/roles/ufw/tasks/main.yml
+++ b/ansible/playbooks/roles/ufw/tasks/main.yml
@@ -36,3 +36,42 @@
   community.general.ufw:
     state: enabled
   become: true
+
+# Configure Docker interaction via DOCKER-USER chain
+- name: Ensure DOCKER-USER chain exists
+  ansible.builtin.command: iptables -nL DOCKER-USER
+  changed_when: false
+  failed_when: false
+  register: docker_user_chain
+  become: true
+
+- name: Create DOCKER-USER chain if absent
+  ansible.builtin.command: iptables -N DOCKER-USER
+  when: docker_user_chain.rc != 0
+  become: true
+
+- name: Ensure RETURN rule exists in DOCKER-USER
+  ansible.builtin.command: iptables -C DOCKER-USER -j RETURN
+  changed_when: false
+  failed_when: false
+  register: docker_user_return
+  become: true
+
+- name: Add RETURN rule to DOCKER-USER
+  ansible.builtin.command: iptables -I DOCKER-USER -j RETURN
+  when: docker_user_return.rc != 0
+  become: true
+
+- name: Block Docker-exposed ports via DOCKER-USER
+  ansible.builtin.command: iptables -C DOCKER-USER -p tcp --dport {{ item }} -j DROP
+  with_items: "{{ ufw_docker_blocked_ports | default([]) }}"
+  changed_when: false
+  failed_when: false
+  register: docker_block_check
+  become: true
+
+- name: Insert DROP rules for Docker ports
+  ansible.builtin.command: iptables -I DOCKER-USER -p tcp --dport {{ item.item }} -j DROP
+  with_items: "{{ docker_block_check.results }}"
+  when: item.rc != 0
+  become: true


### PR DESCRIPTION
## Summary
- allow specifying host ports that should be blocked from Docker
- configure DOCKER-USER chain in the UFW role
- document new `ufw_docker_blocked_ports` variable

## Testing
- `./scripts/run-lint.sh` *(fails: yamllint is not installed)*


------
https://chatgpt.com/codex/tasks/task_e_6867067e89f88322a56efd5280f02cc3