### PR TITLE
Add Duplicati role

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Orchestration Oasis
 
-Orchestration Oasis is an infrastructure automation project built around **Ansible**. It currently features roles for Docker, UFW, Fail2ban, pCloud, Semaphore, and Zerotier, and a Dashy-based Dashboard (using Docker Compose) to help configure a Debian 12 server.
+Orchestration Oasis is an infrastructure automation project built around **Ansible**. It currently features roles for Docker, UFW, Fail2ban, pCloud, Semaphore, Zerotier, and Duplicati, and a Dashy-based Dashboard (using Docker Compose) to help configure a Debian 12 server.
 Windows hosts can also be provisioned using Chocolatey. A dedicated role installs Chocolatey, and another role installs the optional Chocolatey GUI.
 The list below tracks the remaining work before the first stable release.
 

--- a/ansible/playbooks/install_duplicati.yml
+++ b/ansible/playbooks/install_duplicati.yml
@@ -1,0 +1,6 @@
+---
+- name: Install and configure Duplicati
+  hosts: duplicati
+  become: true
+  roles:
+    - duplicati

--- a/ansible/playbooks/roles/duplicati/defaults/main.yml
+++ b/ansible/playbooks/roles/duplicati/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+duplicati_version: "latest"
+duplicati_dir: "/opt/duplicati"
+duplicati_puid: "1000"
+duplicati_pgid: "1000"
+duplicati_timezone: "Etc/UTC"
+duplicati_settings_key: ""
+duplicati_port: 8200

--- a/ansible/playbooks/roles/duplicati/readme.md
+++ b/ansible/playbooks/roles/duplicati/readme.md
@@ -1,0 +1,15 @@
+# Duplicati Role
+
+Deploys [Duplicati](https://www.duplicati.com/) using Docker Compose.
+
+## Variables
+
+- `duplicati_version`: Docker image tag (default `latest`)
+- `duplicati_dir`: Directory for the compose file (default `/opt/duplicati`)
+- `duplicati_puid`: User ID for the container (default `1000`)
+- `duplicati_pgid`: Group ID for the container (default `1000`)
+- `duplicati_timezone`: Time zone (default `Etc/UTC`)
+- `duplicati_settings_key`: Optional settings encryption key (default empty)
+- `duplicati_port`: Host port for the web UI (default `8200`)
+
+Store sensitive values outside version control if required.

--- a/ansible/playbooks/roles/duplicati/tasks/main.yml
+++ b/ansible/playbooks/roles/duplicati/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+- name: Ensure Duplicati directory exists
+  ansible.builtin.file:
+    path: "{{ duplicati_dir }}"
+    state: directory
+    mode: '0755'
+
+- name: Deploy docker-compose file
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
+    dest: "{{ duplicati_dir }}/docker-compose.yml"
+    mode: '0644'
+
+- name: Launch Duplicati stack
+  community.docker.docker_compose_v2:
+    project_src: "{{ duplicati_dir }}"
+    state: present
+  register: duplicati_compose
+
+- name: Display compose status
+  ansible.builtin.debug:
+    var: duplicati_compose

--- a/ansible/playbooks/roles/duplicati/templates/docker-compose.yml.j2
+++ b/ansible/playbooks/roles/duplicati/templates/docker-compose.yml.j2
@@ -1,0 +1,22 @@
+version: '3'
+services:
+  duplicati:
+    image: lscr.io/linuxserver/duplicati:{{ duplicati_version }}
+    restart: unless-stopped
+    environment:
+      PUID: "{{ duplicati_puid }}"
+      PGID: "{{ duplicati_pgid }}"
+      TZ: "{{ duplicati_timezone }}"
+{% if duplicati_settings_key %}
+      SETTINGS_ENCRYPTION_KEY: "{{ duplicati_settings_key }}"
+{% endif %}
+    volumes:
+      - config:/config
+      - backups:/backups
+      - source:/source
+    ports:
+      - "{{ duplicati_port }}:8200"
+volumes:
+  config:
+  backups:
+  source:


### PR DESCRIPTION
## Summary
- add Duplicati role to deploy container with Docker Compose
- create playbook to install the new role
- document Duplicati in the project README

## Testing
- `./scripts/run-lint.sh` *(fails: yamllint is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68697cb3f1788322b2950ee8de36f2af