### PR TITLE
Add default password variable for Duplicati

### DIFF
--- a/ansible/playbooks/roles/duplicati/defaults/main.yml
+++ b/ansible/playbooks/roles/duplicati/defaults/main.yml
@@ -6,3 +6,4 @@ duplicati_pgid: "1000"
 duplicati_timezone: "Etc/UTC"
 duplicati_settings_key: ""
 duplicati_port: 8200
+duplicati_web_password: "changeme"

--- a/ansible/playbooks/roles/duplicati/readme.md
+++ b/ansible/playbooks/roles/duplicati/readme.md
@@ -11,5 +11,6 @@ Deploys [Duplicati](https://www.duplicati.com/) using Docker Compose.
 - `duplicati_timezone`: Time zone (default `Etc/UTC`)
 - `duplicati_settings_key`: Optional settings encryption key (default empty)
 - `duplicati_port`: Host port for the web UI (default `8200`)
+- `duplicati_web_password`: Password for the web UI (default `""`)
 
 Store sensitive values outside version control if required.

--- a/ansible/playbooks/roles/duplicati/templates/docker-compose.yml.j2
+++ b/ansible/playbooks/roles/duplicati/templates/docker-compose.yml.j2
@@ -10,6 +10,7 @@ services:
 {% if duplicati_settings_key %}
       SETTINGS_ENCRYPTION_KEY: "{{ duplicati_settings_key }}"
 {% endif %}
+      DUPLICATI__WEBSERVICE_PASSWORD: "{{ duplicati_web_password }}"
     volumes:
       - config:/config
       - backups:/backups


### PR DESCRIPTION
## Summary
- set `duplicati_web_password` variable with default `changeme`
- pass password to the Duplicati container
- document the new variable
- document an empty default for the password in README

## Testing
- `./scripts/run-lint.sh` *(fails: yamllint and ansible-lint not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6869806331ac832280e144f81ee024ad