### PR TITLE
Add Hashicorp Vault role

### DIFF
--- a/ansible/playbooks/install_dashboard.yml
+++ b/ansible/playbooks/install_dashboard.yml
@@ -4,4 +4,3 @@
   become: true
   roles:
     - dashboard
-

--- a/ansible/playbooks/install_vault.yml
+++ b/ansible/playbooks/install_vault.yml
@@ -1,0 +1,6 @@
+---
+- name: Install and configure Vault
+  hosts: vault
+  become: true
+  roles:
+    - vault

--- a/ansible/playbooks/install_zerotier.yml
+++ b/ansible/playbooks/install_zerotier.yml
@@ -4,4 +4,3 @@
   become: true
   roles:
     - zerotier
-

--- a/ansible/playbooks/roles/vault/defaults/main.yml
+++ b/ansible/playbooks/roles/vault/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+vault_version: "latest"
+vault_dir: "/opt/vault"
+vault_port: 8200
+vault_dev_root_token_id: "root"

--- a/ansible/playbooks/roles/vault/readme.md
+++ b/ansible/playbooks/roles/vault/readme.md
@@ -1,0 +1,12 @@
+# Vault Role
+
+Deploys [HashiCorp Vault](https://www.vaultproject.io/) using Docker Compose in dev mode.
+
+## Variables
+
+- `vault_version`: Docker image tag (default `latest`)
+- `vault_dir`: Directory for the compose file (default `/opt/vault`)
+- `vault_port`: Host port for the Vault UI and API (default `8200`)
+- `vault_dev_root_token_id`: Root token for dev mode (default `"root"`)
+
+Store any sensitive values outside version control if required.

--- a/ansible/playbooks/roles/vault/tasks/main.yml
+++ b/ansible/playbooks/roles/vault/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+- name: Ensure Vault directory exists
+  ansible.builtin.file:
+    path: "{{ vault_dir }}"
+    state: directory
+    mode: '0755'
+
+- name: Deploy docker-compose file
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
+    dest: "{{ vault_dir }}/docker-compose.yml"
+    mode: '0644'
+
+- name: Launch Vault stack
+  community.docker.docker_compose_v2:
+    project_src: "{{ vault_dir }}"
+    state: present
+  register: vault_compose
+
+- name: Display compose status
+  ansible.builtin.debug:
+    var: vault_compose

--- a/ansible/playbooks/roles/vault/templates/docker-compose.yml.j2
+++ b/ansible/playbooks/roles/vault/templates/docker-compose.yml.j2
@@ -1,0 +1,16 @@
+version: '3'
+services:
+  vault:
+    image: hashicorp/vault:{{ vault_version }}
+    restart: unless-stopped
+    cap_add:
+      - IPC_LOCK
+    environment:
+      VAULT_DEV_ROOT_TOKEN_ID: "{{ vault_dev_root_token_id }}"
+      VAULT_DEV_LISTEN_ADDRESS: "0.0.0.0:8200"
+    ports:
+      - "{{ vault_port }}:8200"
+    volumes:
+      - vault-data:/vault/file
+volumes:
+  vault-data:


### PR DESCRIPTION
## Summary
- create Vault role with Docker Compose
- document Vault role variables
- add playbook to deploy Vault
- remove trailing blank lines from Dashboard and Zerotier playbooks

## Testing
- `bash scripts/run-lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_686acd48ca5c8322875760601357a7bf