### PR TITLE
Resolve Vault port conflict

### DIFF
--- a/ansible/playbooks/roles/vault/defaults/main.yml
+++ b/ansible/playbooks/roles/vault/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 vault_version: "latest"
 vault_dir: "/opt/vault"
-vault_port: 8200
+vault_port: 8201
 vault_dev_root_token_id: "root"

--- a/ansible/playbooks/roles/vault/readme.md
+++ b/ansible/playbooks/roles/vault/readme.md
@@ -6,7 +6,7 @@ Deploys [HashiCorp Vault](https://www.vaultproject.io/) using Docker Compose in 
 
 - `vault_version`: Docker image tag (default `latest`)
 - `vault_dir`: Directory for the compose file (default `/opt/vault`)
-- `vault_port`: Host port for the Vault UI and API (default `8200`)
+- `vault_port`: Host port for the Vault UI and API (default `8201`)
 - `vault_dev_root_token_id`: Root token for dev mode (default `"root"`)
 
 Store any sensitive values outside version control if required.


### PR DESCRIPTION
## Summary
- assign Vault a unique default port to avoid conflicts on single server

## Testing
- `./scripts/run-lint.sh` *(fails: yamllint and ansible-lint not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686ad3efb7388322980181dca7483743