### PR TITLE
Add docker dynamic bind role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Generated locally – never commit
+docker-compose.override.yml

--- a/ansible/playbooks/roles/docker_dynamic_bind/handlers/main.yml
+++ b/ansible/playbooks/roles/docker_dynamic_bind/handlers/main.yml
@@ -1,0 +1,7 @@
+# ansible/playbooks/roles/docker_dynamic_bind/handlers/main.yml
+---
+- name: Restart containers
+  ansible.builtin.command:
+    cmd: docker compose -f /opt/oasis/docker-compose.yml -f /opt/oasis/docker-compose.override.yml up -d
+  become: true
+  changed_when: false

--- a/ansible/playbooks/roles/docker_dynamic_bind/tasks/main.yml
+++ b/ansible/playbooks/roles/docker_dynamic_bind/tasks/main.yml
@@ -1,0 +1,21 @@
+# ansible/playbooks/roles/docker_dynamic_bind/tasks/main.yml
+---
+- name: Detect ZeroTier interface
+  ansible.builtin.set_fact:
+    zt_interface: "{{ ansible_interfaces | select('match', '^zt') | list | first | default('') }}"
+
+- name: Fail if ZeroTier interface is not found
+  ansible.builtin.fail:
+    msg: "No ZeroTier interface found"
+  when: zt_interface | length == 0
+
+- name: Gather ZeroTier IP address
+  ansible.builtin.set_fact:
+    zt_ip: "{{ hostvars[inventory_hostname]['ansible_' + zt_interface]['ipv4']['address'] }}"
+
+- name: Deploy docker-compose override
+  ansible.builtin.template:
+    src: docker-compose.override.yml.j2
+    dest: /opt/oasis/docker-compose.override.yml
+    mode: '0600'
+  notify: Restart containers

--- a/ansible/playbooks/roles/docker_dynamic_bind/templates/docker-compose.override.yml.j2
+++ b/ansible/playbooks/roles/docker_dynamic_bind/templates/docker-compose.override.yml.j2
@@ -1,0 +1,7 @@
+services:
+  vault:
+    ports:
+      - "{{ zt_ip }}:8200:8200"
+  duplicati:
+    ports:
+      - "{{ zt_ip }}:8201:8200"


### PR DESCRIPTION
## Summary
- add new role `docker_dynamic_bind` to gather ZeroTier interface IP and generate a compose override
- implement handler to restart containers
- template ports using the discovered IP
- ignore generated override file

## Testing
- `ansible-lint ansible/playbooks/roles/docker_dynamic_bind`

------
https://chatgpt.com/codex/tasks/task_e_6871067dd55483228cda6d8fe1debf0a