### PR TITLE
Simplify site playbook

### DIFF
--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -1,11 +1,16 @@
 ---
-- name: Configure server
-  hosts: all
-  become: true
-  roles:
-    - docker
-    - ufw
-    - fail2ban
-    - pcloud
-    - semaphore
-    - zerotier
+# Master playbook
+#
+# This file orchestrates the infrastructure by importing the individual
+# playbooks. To deploy incrementally, only the dashboard is executed by
+# default. Uncomment additional imports as you are ready to roll out more
+# services.
+
+- import_playbook: playbooks/install_dashboard.yml  # noqa name[play]
+
+# - import_playbook: playbooks/install_docker.yml
+# - import_playbook: playbooks/install_ufw.yml
+# - import_playbook: playbooks/install_fail2ban.yml
+# - import_playbook: playbooks/install_pcloud.yml
+# - import_playbook: playbooks/install_semaphore.yml
+# - import_playbook: playbooks/install_zerotier.yml


### PR DESCRIPTION
## Summary
- simplify the site playbook
- only import the dashboard setup by default

## Testing
- `scripts/run-lint.sh` *(fails: yaml[empty-lines] in .github/workflows/deploy.yml)*
- `scripts/run-lint.sh ansible`


------
https://chatgpt.com/codex/tasks/task_e_6884a3460ad48322af0c55b2cfd34280