### PR TITLE
Setup local Ansible deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,8 @@
 name: Deploy
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
 
 jobs:
@@ -21,6 +23,5 @@ jobs:
 
       - name: Execute playbook
         working-directory: ansible
-        run: |
-          ansible-playbook -i inventories/production/hosts.yml site.yml --become
+        run: ansible-playbook -i inventories/production/hosts.yml site.yml --become
 

--- a/ansible/inventories/production/hosts.yml
+++ b/ansible/inventories/production/hosts.yml
@@ -1,0 +1,5 @@
+all:
+  hosts:
+    localhost:
+      ansible_connection: local
+

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -1,16 +1,12 @@
 ---
-# Master playbook
-#
-# This file orchestrates the infrastructure by importing the individual
-# playbooks. To deploy incrementally, only the dashboard is executed by
-# default. Uncomment additional imports as you are ready to roll out more
-# services.
+- hosts: localhost
+  become: true
+  roles:
+    - docker
+    - ufw
+    - fail2ban
+    - duplicati
+    - dashboard
+    - semaphore
+    - zerotier
 
-- import_playbook: playbooks/install_dashboard.yml  # noqa name[play]
-
-# - import_playbook: playbooks/install_docker.yml
-# - import_playbook: playbooks/install_ufw.yml
-# - import_playbook: playbooks/install_fail2ban.yml
-# - import_playbook: playbooks/install_pcloud.yml
-# - import_playbook: playbooks/install_semaphore.yml
-# - import_playbook: playbooks/install_zerotier.yml


### PR DESCRIPTION
## Summary
- add production inventory for localhost usage
- simplify site.yml to run roles directly on localhost
- update GitHub Actions workflow to run on push and install Ansible/collections

## Testing
- `./scripts/run-lint.sh` *(fails: yamllint is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6884aa9e2e7c8322916b518e3021efaa