### PR TITLE
Fix ansible-lint spacing issues

### DIFF
--- a/ansible/inventories/production/hosts.yml
+++ b/ansible/inventories/production/hosts.yml
@@ -2,4 +2,3 @@ all:
   hosts:
     localhost:
       ansible_connection: local
-

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: configure host
+  hosts: localhost
   become: true
   roles:
     - docker
@@ -9,4 +10,3 @@
     - dashboard
     - semaphore
     - zerotier
-


### PR DESCRIPTION
## Summary
- clean up trailing blank line in `hosts.yml`
- add play name and remove trailing blank line in `site.yml`

## Testing
- `ansible-lint > ansible-lint.log && tail -n 20 ansible-lint.log`

------
https://chatgpt.com/codex/tasks/task_e_6884ba2244288322a7892557c2f16fac