### PR TITLE
Add Dashboard role for Dashy with ZeroTier

### DIFF
--- a/ansible/inventories/production/hosts.yml
+++ b/ansible/inventories/production/hosts.yml
@@ -1,0 +1,4 @@
+all:
+  hosts:
+    localhost:
+      ansible_connection: local

--- a/ansible/playbooks/roles/dashboard/defaults/main.yml
+++ b/ansible/playbooks/roles/dashboard/defaults/main.yml
@@ -1,1 +1,5 @@
 ---
+dashboard_dir: "/opt/dashboard"
+dashboard_image: "lissy93/dashy:latest"
+dashboard_port: 4000
+dashboard_volume: "dashy-data"

--- a/ansible/playbooks/roles/dashboard/tasks/main.yml
+++ b/ansible/playbooks/roles/dashboard/tasks/main.yml
@@ -14,19 +14,19 @@
 
 - name: Ensure Dashboard directory exists
   ansible.builtin.file:
-    path: /opt/dashboard
+    path: "{{ dashboard_dir }}"
     state: directory
     mode: '0755'
 
 - name: Deploy docker-compose file
   ansible.builtin.template:
     src: docker-compose.yml.j2
-    dest: /opt/dashboard/docker-compose.yml
+    dest: "{{ dashboard_dir }}/docker-compose.yml"
     mode: '0644'
 
 - name: Launch Dashboard stack
   community.docker.docker_compose_v2:
-    project_src: /opt/dashboard
+    project_src: "{{ dashboard_dir }}"
     state: present
   register: dashboard_compose
 

--- a/ansible/playbooks/roles/dashboard/templates/docker-compose.yml.j2
+++ b/ansible/playbooks/roles/dashboard/templates/docker-compose.yml.j2
@@ -1,11 +1,10 @@
-version: '3'
 services:
   dashy:
-    image: lissy93/dashy:latest
+    image: {{ dashboard_image }}
     restart: unless-stopped
     ports:
-      - "{{ zerotier_ip }}:4000:8080"
+      - "{{ zerotier_ip }}:{{ dashboard_port }}:8080"
     volumes:
-      - dashy-data:/app/user-data
+      - {{ dashboard_volume }}:/app/user-data
 volumes:
-  dashy-data:
+  {{ dashboard_volume }}:


### PR DESCRIPTION
## Summary
- add inventory for localhost
- set dashboard defaults
- generate docker-compose from template using ZeroTier IP
- launch Dashy via compose

## Testing
- `ansible-lint ansible/playbooks/install_dashboard.yml`

------
https://chatgpt.com/codex/tasks/task_e_6884e406a9b48322895781b372065762