### PR TITLE
Add role-specific deployment workflows

### DIFF
--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -1,8 +1,14 @@
 ---
-name: Deploy
+name: Deploy Dashboard
 
 on:
+  schedule:
+    - cron: '0 4 * * *'
   workflow_dispatch:
+  push:
+    paths:
+      - 'ansible/playbooks/roles/dashboard/**'
+      - 'ansible/site.yml'
 
 jobs:
   deploy:
@@ -10,16 +16,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-
       - name: Install Ansible
         run: |
           sudo apt-get update
           sudo apt-get install -y ansible
-
       - name: Install Ansible collections
         run: ansible-galaxy collection install -r ansible/requirements.yml
-
       - name: Execute playbook
         working-directory: ansible
         run: |
-          ansible-playbook -i inventories/production/hosts.yml site.yml --become
+          ansible-playbook site.yml -i inventories/production/hosts.yml \
+            --tags dashboard --become

--- a/.github/workflows/deploy-duplicati.yml
+++ b/.github/workflows/deploy-duplicati.yml
@@ -1,8 +1,14 @@
 ---
-name: Deploy
+name: Deploy Duplicati
 
 on:
+  schedule:
+    - cron: '30 4 * * *'
   workflow_dispatch:
+  push:
+    paths:
+      - 'ansible/playbooks/roles/duplicati/**'
+      - 'ansible/site.yml'
 
 jobs:
   deploy:
@@ -10,16 +16,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-
       - name: Install Ansible
         run: |
           sudo apt-get update
           sudo apt-get install -y ansible
-
       - name: Install Ansible collections
         run: ansible-galaxy collection install -r ansible/requirements.yml
-
       - name: Execute playbook
         working-directory: ansible
         run: |
-          ansible-playbook -i inventories/production/hosts.yml site.yml --become
+          ansible-playbook site.yml -i inventories/production/hosts.yml \
+            --tags duplicati --become

--- a/.github/workflows/deploy-semaphore.yml
+++ b/.github/workflows/deploy-semaphore.yml
@@ -1,8 +1,14 @@
 ---
-name: Deploy
+name: Deploy Semaphore
 
 on:
+  schedule:
+    - cron: '45 4 * * *'
   workflow_dispatch:
+  push:
+    paths:
+      - 'ansible/playbooks/roles/semaphore/**'
+      - 'ansible/site.yml'
 
 jobs:
   deploy:
@@ -10,16 +16,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-
       - name: Install Ansible
         run: |
           sudo apt-get update
           sudo apt-get install -y ansible
-
       - name: Install Ansible collections
         run: ansible-galaxy collection install -r ansible/requirements.yml
-
       - name: Execute playbook
         working-directory: ansible
         run: |
-          ansible-playbook -i inventories/production/hosts.yml site.yml --become
+          ansible-playbook site.yml -i inventories/production/hosts.yml \
+            --tags semaphore --become

--- a/.github/workflows/deploy-vault.yml
+++ b/.github/workflows/deploy-vault.yml
@@ -1,8 +1,14 @@
 ---
-name: Deploy
+name: Deploy Vault
 
 on:
+  schedule:
+    - cron: '15 4 * * *'
   workflow_dispatch:
+  push:
+    paths:
+      - 'ansible/playbooks/roles/vault/**'
+      - 'ansible/site.yml'
 
 jobs:
   deploy:
@@ -10,16 +16,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-
       - name: Install Ansible
         run: |
           sudo apt-get update
           sudo apt-get install -y ansible
-
       - name: Install Ansible collections
         run: ansible-galaxy collection install -r ansible/requirements.yml
-
       - name: Execute playbook
         working-directory: ansible
         run: |
-          ansible-playbook -i inventories/production/hosts.yml site.yml --become
+          ansible-playbook site.yml -i inventories/production/hosts.yml \
+            --tags vault --become

--- a/.github/workflows/full-deploy.yml
+++ b/.github/workflows/full-deploy.yml
@@ -1,5 +1,5 @@
 ---
-name: Deploy
+name: Full Deploy
 
 on:
   workflow_dispatch:
@@ -10,16 +10,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-
       - name: Install Ansible
         run: |
           sudo apt-get update
           sudo apt-get install -y ansible
-
       - name: Install Ansible collections
         run: ansible-galaxy collection install -r ansible/requirements.yml
-
       - name: Execute playbook
         working-directory: ansible
         run: |
-          ansible-playbook -i inventories/production/hosts.yml site.yml --become
+          ansible-playbook site.yml -i inventories/production/hosts.yml \
+            --become


### PR DESCRIPTION
## Summary
- automate deployments for dashboard, vault, duplicati and semaphore roles
- allow full deploy via a separate workflow
- fix lint issue in existing deploy workflow

## Testing
- `./scripts/run-lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_6884e69c4fa48322a06dcb8b8cb88688