### PR TITLE
Add manual trigger for dashboard deployment

### DIFF
--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -1,9 +1,11 @@
 ---
 name: Deploy Dashboard
 
-'on':
+on:
   push:
-    branches: [main]
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary
- allow running deploy-dashboard workflow manually

## Testing
- `./scripts/run-lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_6884f6bc6ba88322bd6a19a57d90855d