### PR TITLE
Add apt role for patching

### DIFF
--- a/.github/workflows/deploy-apt.yml
+++ b/.github/workflows/deploy-apt.yml
@@ -1,0 +1,47 @@
+---
+name: Apply Updates
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+  push:
+    paths:
+      - 'ansible/playbooks/roles/apt/**'
+      - 'ansible/playbooks/apply_updates.yml'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install Ansible and ansible-lint
+        run: |
+          pip install ansible ansible-lint
+      - name: Run ansible-lint
+        env:
+          ANSIBLE_CONFIG: ansible/ansible.cfg
+        run: ansible-lint ansible/
+
+  deploy:
+    needs: lint
+    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: self-hosted
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install Ansible
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ansible
+      - name: Install Ansible collections
+        run: ansible-galaxy collection install -r ansible/requirements.yml
+      - name: Execute apply_updates playbook
+        working-directory: ansible
+        run: |
+          ansible-playbook playbooks/apply_updates.yml -i inventories/production/hosts.yml --become

--- a/ansible/playbooks/apply_updates.yml
+++ b/ansible/playbooks/apply_updates.yml
@@ -1,0 +1,6 @@
+---
+- name: Update and upgrade system packages
+  hosts: all
+  become: true
+  roles:
+    - apt

--- a/ansible/playbooks/roles/apt/defaults/main.yml
+++ b/ansible/playbooks/roles/apt/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+apt_cache_valid_time: 3600
+apt_upgrade_type: dist
+apt_autoremove: true
+apt_autoclean: true

--- a/ansible/playbooks/roles/apt/readme.md
+++ b/ansible/playbooks/roles/apt/readme.md
@@ -1,0 +1,10 @@
+# Apt Role
+
+Updates and upgrades packages on Debian-based systems using the `apt` module.
+
+## Variables
+
+- `apt_cache_valid_time`: Cache validity in seconds before refreshing (default `3600`).
+- `apt_upgrade_type`: Upgrade type passed to the module (default `dist`).
+- `apt_autoremove`: Whether to remove unused packages (default `true`).
+- `apt_autoclean`: Whether to clean the apt cache (default `true`).

--- a/ansible/playbooks/roles/apt/tasks/main.yml
+++ b/ansible/playbooks/roles/apt/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+- name: Update apt cache
+  ansible.builtin.apt:
+    update_cache: true
+    cache_valid_time: "{{ apt_cache_valid_time }}"
+  become: true
+
+- name: Upgrade all packages
+  ansible.builtin.apt:
+    upgrade: "{{ apt_upgrade_type }}"
+  become: true
+
+- name: Autoremove unused packages
+  ansible.builtin.apt:
+    autoremove: true
+  when: apt_autoremove
+  become: true
+
+- name: Autoclean apt cache
+  ansible.builtin.apt:
+    autoclean: true
+  when: apt_autoclean
+  become: true


### PR DESCRIPTION
## Summary
- add apt role to run basic system updates
- document the new apt role
- add playbook to apply updates
- add GitHub Actions workflow to run updates on a schedule or manually

## Testing
- `./scripts/run-lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_688502233bdc8322b222df36c5d076b3