### PR TITLE
Use GitHub secrets for pcloud token

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,5 +21,7 @@ jobs:
 
       - name: Execute playbook
         working-directory: ansible
+        env:
+          PCLOUD_TOKEN: ${{ secrets.PCLOUD_TOKEN }}
         run: |
           ansible-playbook -i inventories/production/hosts.yml site.yml --become

--- a/.github/workflows/full-deploy.yml
+++ b/.github/workflows/full-deploy.yml
@@ -18,6 +18,8 @@ jobs:
         run: ansible-galaxy collection install -r ansible/requirements.yml
       - name: Execute playbook
         working-directory: ansible
+        env:
+          PCLOUD_TOKEN: ${{ secrets.PCLOUD_TOKEN }}
         run: |
           ansible-playbook site.yml -i inventories/production/hosts.yml \
             --become

--- a/ansible/playbooks/roles/pcloud/readme.md
+++ b/ansible/playbooks/roles/pcloud/readme.md
@@ -15,3 +15,5 @@ This guide explains how to generate an authentication token for pCloud using rcl
 - Log in to pCloud via the browser link provided by rclone and authorize access.
 - Once completed, rclone will display a token in JSON format (e.g., `{"access_token":"xxx","token_type":"bearer","expiry":"2025-05-05T22:00:00Z"}`).
 - Save this token, including the curly braces, and provide it to the role using the `pcloud_token` variable. You can keep the value in `defaults/main.yml` during testing or store it securely with `ansible-vault` in your inventory.
+-
+- The role also supports the `PCLOUD_TOKEN` environment variable. When set, this variable overrides other token sources, making it convenient to pass the token through GitHub Secrets.

--- a/ansible/playbooks/roles/pcloud/tasks/main.yml
+++ b/ansible/playbooks/roles/pcloud/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Set pCloud token from environment
+  ansible.builtin.set_fact:
+    pcloud_token: "{{ lookup('env', 'PCLOUD_TOKEN') }}"
+  when: lookup('env', 'PCLOUD_TOKEN') | default('') != ''
+
 - name: Retrieve pCloud token from Bitwarden
   ansible.builtin.set_fact:
     pcloud_token: >-
@@ -10,6 +15,7 @@
         client_secret=client_secret,
         password=password,
       ) }}
+  when: pcloud_token | default('') == ''
 
 - name: Install rclone
   ansible.builtin.apt:


### PR DESCRIPTION
## Summary
- allow pcloud role to read token from `PCLOUD_TOKEN`
- document the environment variable usage in the pcloud role README
- expose `PCLOUD_TOKEN` to playbook runs in deploy workflows

## Testing
- `./scripts/run-lint.sh` *(fails: yaml[truthy])*

------
https://chatgpt.com/codex/tasks/task_e_68863cc544a4832286c681675a239cee