### PR TITLE
Add pCloud CI deployment workflow

### DIFF
--- a/.github/workflows/deploy-pcloud.yml
+++ b/.github/workflows/deploy-pcloud.yml
@@ -1,0 +1,49 @@
+---
+name: Deploy pCloud
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+  schedule:
+    - cron: '20 2 * * 1'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install Ansible and ansible-lint
+        run: |
+          pip install ansible ansible-lint
+      - name: Run ansible-lint
+        env:
+          ANSIBLE_CONFIG: ansible/ansible.cfg
+        run: ansible-lint ansible/
+
+  deploy:
+    needs: lint
+    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: self-hosted
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install Ansible
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ansible
+      - name: Install Ansible collections
+        run: ansible-galaxy collection install -r ansible/requirements.yml
+      - name: Execute playbook
+        working-directory: ansible
+        env:
+          PCLOUD_TOKEN: ${{ secrets.PCLOUD_TOKEN }}
+          ANSIBLE_DISPLAY_ARGS_TO_STDOUT: 'false'
+        run: |
+          ansible-playbook playbooks/install_pcloud.yml -i inventories/production/hosts.yml --become


### PR DESCRIPTION
## Summary
- add a workflow to deploy pCloud on a self-hosted runner

## Testing
- `pip install yamllint ansible ansible-lint`
- `./scripts/run-lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_688644717e188322b9c3a2583993c4ff