### PR TITLE
Fix missing pcloud group in default inventory

### DIFF
--- a/ansible/inventories/production/hosts.yml
+++ b/ansible/inventories/production/hosts.yml
@@ -2,3 +2,7 @@ all:
   hosts:
     localhost:
       ansible_connection: local
+
+pcloud:
+  hosts:
+    localhost:


### PR DESCRIPTION
## Summary
- include `pcloud` group in the production inventory so the pCloud playbook runs

## Testing
- `./scripts/run-lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_68864746ee708322a0990384b14c0b72