### PR TITLE
Fix rclone config template

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,9 @@ perform the additional checks.
      ```bash
      docker run --rm -v $(pwd):/github/workspace -e VALIDATE_ALL_CODEBASE=true -e VALIDATE_MARKDOWN=true -e VALIDATE_YAML=true -e VALIDATE_ANSIBLE=true -e DEFAULT_BRANCH=main github/super-linter:v5
      ```
-    - If warnings appear for `pcloud/templates/rclone.conf.j2` or `rclone-pcloud.service.j2`, add `---`.
-    - `---` has been added to these templates to satisfy the linter.
+    - If yamllint warns about `pcloud/templates/rclone.conf.j2` or `rclone-pcloud.service.j2`,
+      ignore the message or add `# yamllint disable-file` to the top of the template.
+      These files are not YAML, so adding `---` will break rclone and systemd.
 
 2. [x] **Integrate Bitwarden Web API**:
     - Delete `ansible/playbooks/roles/pcloud/vars/vault.yml`:

--- a/ansible/playbooks/roles/pcloud/templates/rclone-pcloud.service.j2
+++ b/ansible/playbooks/roles/pcloud/templates/rclone-pcloud.service.j2
@@ -1,4 +1,4 @@
----
+# yamllint disable-file
 [Unit]
 Description=rclone mount for pCloud
 After=network-online.target

--- a/ansible/playbooks/roles/pcloud/templates/rclone.conf.j2
+++ b/ansible/playbooks/roles/pcloud/templates/rclone.conf.j2
@@ -1,4 +1,4 @@
----
+# yamllint disable-file
 [pcloud]
 type = pcloud
 hostname = {{ pcloud_hostname }}


### PR DESCRIPTION
## Summary
- handle yamllint warnings for rclone and systemd templates
- ensure generated rclone files work with rclone and systemd

## Testing
- `./scripts/run-lint.sh` *(fails: unknown module 'community.docker.docker_compose_v2')*

------
https://chatgpt.com/codex/tasks/task_e_68864e520be0832293e7283d2105c0ea