### PR TITLE
Add rclone service example

### DIFF
--- a/ansible/playbooks/roles/pcloud/defaults/main.yml
+++ b/ansible/playbooks/roles/pcloud/defaults/main.yml
@@ -19,6 +19,5 @@ pcloud_rclone_options:
   - "--vfs-cache-mode full"
   - "--cache-dir /var/cache/rclone"
   - "--dir-cache-time 5m"
-  - "--nonempty"
   - "--log-level INFO"
   - "--log-file {{ pcloud_log_file }}"

--- a/ansible/playbooks/roles/pcloud/templates/rclone-pcloud.service.j2
+++ b/ansible/playbooks/roles/pcloud/templates/rclone-pcloud.service.j2
@@ -1,4 +1,5 @@
 # yamllint disable-file
+# Note: {{ pcloud_mount_point }} must be empty before starting (managed by Ansible)
 [Unit]
 Description=rclone mount for pCloud
 After=network-online.target


### PR DESCRIPTION
## Summary
- provide a ready-to-use systemd service file for rclone
- drop deprecated `--nonempty` option from defaults
- remove static service file and rely on template

## Testing
- `./scripts/run-lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_68865a2becc08322b8810c0c38917be0