### PR TITLE
Add cleanup in pCloud role

### DIFF
--- a/ansible/playbooks/roles/pcloud/tasks/main.yml
+++ b/ansible/playbooks/roles/pcloud/tasks/main.yml
@@ -132,6 +132,50 @@
     daemon_reload: true
   become: true
 
+# Clean up any existing rclone mount before (re)starting the service
+- name: Check for existing rclone mount process
+  ansible.builtin.shell: pgrep -f "rclone mount pcloud:" || true
+  register: rclone_process
+  changed_when: false
+  failed_when: false
+
+- name: Kill rclone process if running
+  ansible.builtin.shell: killall rclone || true
+  when: rclone_process.rc == 0
+  changed_when: rclone_process.rc == 0
+  failed_when: false
+
+- name: Unmount pcloud with fusermount
+  ansible.builtin.shell: >-
+    fusermount -u {{ pcloud_mount_point }} || true
+  changed_when: false
+  failed_when: false
+
+- name: Lazy unmount pcloud
+  ansible.builtin.shell: >-
+    umount -l {{ pcloud_mount_point }} || true
+  changed_when: false
+  failed_when: false
+
+- name: Force unmount pcloud if needed
+  ansible.builtin.shell: >-
+    umount -f {{ pcloud_mount_point }} || true
+  changed_when: false
+  failed_when: false
+
+- name: Remove mount directory if present
+  ansible.builtin.file:
+    path: "{{ pcloud_mount_point }}"
+    state: absent
+
+- name: Recreate empty mount directory
+  ansible.builtin.file:
+    path: "{{ pcloud_mount_point }}"
+    state: directory
+    owner: root
+    group: "{{ pcloud_group }}"
+    mode: '0770'
+
 - name: Enable and start rclone-pcloud service
   ansible.builtin.systemd:
     name: rclone-pcloud.service


### PR DESCRIPTION
## Summary
- move rclone cleanup logic from playbook into `pcloud` role

## Testing
- `./scripts/run-lint.sh` *(fails: yaml[truthy] on 90 files)*

------
https://chatgpt.com/codex/tasks/task_e_68865f0f4e088322b9c466d493945fae