### PR TITLE
Remove pcloud mount cleanup step

### DIFF
--- a/ansible/playbooks/roles/pcloud/tasks/main.yml
+++ b/ansible/playbooks/roles/pcloud/tasks/main.yml
@@ -20,10 +20,6 @@
   changed_when: false
   failed_when: false
 
-- name: "Remove corrupted mountpoint (if needed)"
-  ansible.builtin.file:
-    path: /mnt/pcloud
-    state: absent
 
 - name: "Recreate mountpoint"
   ansible.builtin.file:


### PR DESCRIPTION
## Summary
- stop deleting `/mnt/pcloud` during pCloud setup

## Testing
- `pip install --user yamllint ansible-lint`
- `ansible-galaxy collection install -r ansible/requirements.yml`
- `./scripts/run-lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_68867b242e408322900ea0d48df64dd8