### PR TITLE
Add NetBox role Zerotier integration and CI

### DIFF
--- a/.github/workflows/deploy-netbox.yml
+++ b/.github/workflows/deploy-netbox.yml
@@ -1,0 +1,54 @@
+---
+name: Deploy NetBox
+
+on:
+  push:
+    paths:
+      - 'ansible/playbooks/roles/netbox/**'
+      - 'ansible/playbooks/install_netbox.yml'
+  workflow_dispatch:
+  schedule:
+    - cron: '25 3 * * 1'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install Ansible and ansible-lint
+        run: |
+          pip install ansible ansible-lint
+      - name: Run ansible-lint
+        env:
+          ANSIBLE_CONFIG: ansible/ansible.cfg
+        run: ansible-lint ansible/
+
+  deploy:
+    needs: lint
+    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: self-hosted
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install Ansible
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ansible
+      - name: Install Ansible collections
+        run: ansible-galaxy collection install -r ansible/requirements.yml
+      - name: Execute playbook
+        working-directory: ansible
+        env:
+          NETBOX_DB_PASSWORD: ${{ secrets.NETBOX_DB_PASSWORD }}
+          NETBOX_REDIS_PASSWORD: ${{ secrets.NETBOX_REDIS_PASSWORD }}
+          NETBOX_SECRET_KEY: ${{ secrets.NETBOX_SECRET_KEY }}
+          ANSIBLE_DISPLAY_ARGS_TO_STDOUT: 'false'
+        run: |
+          ansible-playbook playbooks/install_netbox.yml -i inventories/production/hosts.yml \
+            -e "netbox_db_password=${NETBOX_DB_PASSWORD} netbox_redis_password=${NETBOX_REDIS_PASSWORD} netbox_secret_key=${NETBOX_SECRET_KEY}" \
+            --become

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Orchestration Oasis
 
-Orchestration Oasis is an infrastructure automation project built around **Ansible**. It currently features roles for Docker, UFW, Fail2ban, pCloud, Zerotier, and Duplicati, and a Dashy-based Dashboard (using Docker Compose) to help configure a Debian 12 server.
+Orchestration Oasis is an infrastructure automation project built around **Ansible**. It currently features roles for Docker, UFW, Fail2ban, pCloud, Zerotier, Duplicati, and NetBox, and a Dashy-based Dashboard (using Docker Compose) to help configure a Debian 12 server.
 Windows hosts can also be provisioned using Chocolatey. A dedicated role installs Chocolatey, and another role installs the optional Chocolatey GUI.
 The list below tracks the remaining work before the first stable release.
 

--- a/ansible/playbooks/roles/netbox/defaults/main.yml
+++ b/ansible/playbooks/roles/netbox/defaults/main.yml
@@ -6,3 +6,4 @@ netbox_db_user: "netbox"
 netbox_db_password: "netbox"
 netbox_redis_password: "netbox"
 netbox_secret_key: "change-me"
+netbox_port: 8080

--- a/ansible/playbooks/roles/netbox/readme.md
+++ b/ansible/playbooks/roles/netbox/readme.md
@@ -11,5 +11,6 @@ Deploys [NetBox](https://github.com/netbox-community/netbox) using Docker Compos
 - `netbox_db_password`: Database password (default `netbox`)
 - `netbox_redis_password`: Redis password (default `netbox`)
 - `netbox_secret_key`: Django secret key (default `change-me`)
+- `netbox_port`: Host port to expose NetBox (default `8080`)
 
 Store sensitive values outside of version control if required.

--- a/ansible/playbooks/roles/netbox/tasks/main.yml
+++ b/ansible/playbooks/roles/netbox/tasks/main.yml
@@ -1,4 +1,17 @@
 ---
+- name: Detect ZeroTier interface
+  ansible.builtin.set_fact:
+    zerotier_interface: "{{ ansible_interfaces | select('match', '^zt') | list | first | default('') }}"
+
+- name: Fail if ZeroTier interface not found
+  ansible.builtin.fail:
+    msg: "No ZeroTier interface found"
+  when: zerotier_interface | length == 0
+
+- name: Gather ZeroTier IP address
+  ansible.builtin.set_fact:
+    zerotier_ip: "{{ hostvars[inventory_hostname]['ansible_' ~ zerotier_interface]['ipv4']['address'] }}"
+
 - name: Ensure NetBox directory exists
   ansible.builtin.file:
     path: "{{ netbox_dir }}"

--- a/ansible/playbooks/roles/netbox/templates/docker-compose.yml.j2
+++ b/ansible/playbooks/roles/netbox/templates/docker-compose.yml.j2
@@ -23,7 +23,7 @@ services:
     env_file:
       - netbox.env
     ports:
-      - "8080:8080"
+      - "{{ zerotier_ip }}:{{ netbox_port }}:8080"
     volumes:
       - netbox-media:/opt/netbox/netbox/media
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- bind NetBox ports to the ZeroTier interface like the Dashboard role
- add `netbox_port` variable and document it
- mention NetBox in the project README
- create deploy-netbox workflow using GitHub secrets

## Testing
- `./scripts/run-lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_6887af16f7f883229318f147c202d65e