### PR TITLE
Fix netbox inventory group

### DIFF
--- a/ansible/inventories/production/hosts.yml
+++ b/ansible/inventories/production/hosts.yml
@@ -6,3 +6,7 @@ all:
 pcloud:
   hosts:
     localhost:
+
+netbox:
+  hosts:
+    localhost:


### PR DESCRIPTION
## Summary
- add a `netbox` group to the production inventory

## Testing
- `scripts/run-lint.sh` *(fails: `yamllint` and `ansible-lint` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6887b2ede1e48322bb7547668f342f9a