### PR TITLE
Configure NetBox without Redis auth

### DIFF
--- a/ansible/playbooks/roles/netbox/tasks/main.yml
+++ b/ansible/playbooks/roles/netbox/tasks/main.yml
@@ -26,9 +26,14 @@
   loop:
     - { src: 'netbox.env.j2', dest: 'netbox.env' }
     - { src: 'postgres.env.j2', dest: 'postgres.env' }
-    - { src: 'redis.env.j2', dest: 'redis.env' }
   loop_control:
     label: "{{ item.dest }}"
+
+- name: Deploy NetBox configuration
+  ansible.builtin.template:
+    src: configuration.py.j2
+    dest: "{{ netbox_dir }}/configuration.py"
+    mode: '0644'
 
 - name: Deploy docker-compose file
   ansible.builtin.template:

--- a/ansible/playbooks/roles/netbox/templates/configuration.py.j2
+++ b/ansible/playbooks/roles/netbox/templates/configuration.py.j2
@@ -1,0 +1,14 @@
+REDIS = {
+    'tasks': {
+        'HOST': 'redis',
+        'PORT': 6379,
+        'DATABASE': 0,
+        'SSL': False,
+    },
+    'caching': {
+        'HOST': 'redis',
+        'PORT': 6379,
+        'DATABASE': 1,
+        'SSL': False,
+    },
+}

--- a/ansible/playbooks/roles/netbox/templates/docker-compose.yml.j2
+++ b/ansible/playbooks/roles/netbox/templates/docker-compose.yml.j2
@@ -11,8 +11,6 @@ services:
     image: redis:7-alpine
     restart: unless-stopped
     command: redis-server --appendonly yes
-    env_file:
-      - redis.env
     volumes:
       - redis:/data
   netbox:
@@ -25,6 +23,7 @@ services:
     ports:
       - "{{ zerotier_ip }}:{{ netbox_port }}:8080"
     volumes:
+      - ./configuration.py:/etc/netbox/config/configuration.py:ro
       - netbox-media:/opt/netbox/netbox/media
     restart: unless-stopped
 volumes:

--- a/ansible/playbooks/roles/netbox/templates/netbox.env.j2
+++ b/ansible/playbooks/roles/netbox/templates/netbox.env.j2
@@ -4,5 +4,4 @@ DB_NAME={{ netbox_db_name }}
 DB_USER={{ netbox_db_user }}
 DB_PASSWORD={{ netbox_db_password }}
 REDIS_HOST=redis
-REDIS_PASSWORD={{ netbox_redis_password }}
 SECRET_KEY={{ netbox_secret_key }}


### PR DESCRIPTION
## Summary
- avoid passing REDIS password to NetBox
- mount custom configuration to disable Redis authentication

## Testing
- `./scripts/run-lint.sh` *(fails: yaml[truthy] rule)*

------
https://chatgpt.com/codex/tasks/task_e_6887c8e436888322b4570e4cb793163f