### PR TITLE
Add dynamic ALLOWED_HOSTS config

### DIFF
--- a/ansible/playbooks/roles/netbox/templates/configuration.py.j2
+++ b/ansible/playbooks/roles/netbox/templates/configuration.py.j2
@@ -12,3 +12,11 @@ REDIS = {
         'SSL': False,
     },
 }
+
+import os
+
+raw_allowed_hosts = os.getenv('ALLOWED_HOSTS')
+if raw_allowed_hosts:
+    ALLOWED_HOSTS = [h.strip() for h in raw_allowed_hosts.split(',') if h.strip()]
+else:
+    ALLOWED_HOSTS = ["localhost", "127.0.0.1"]


### PR DESCRIPTION
## Summary
- make NetBox ALLOWED_HOSTS configurable via environment variable

## Testing
- `./scripts/run-lint.sh` *(fails: unknown module errors)*

------
https://chatgpt.com/codex/tasks/task_e_6887cdf05840832291a692a934afd062