### PR TITLE
Add NetBox dynamic inventory

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -10,7 +10,7 @@ module_defaults =
     timeout: 30
 
 [inventory]
-enable_plugins = yaml, ini
+enable_plugins = yaml, ini, netbox.netbox.nb_inventory
 
 [privilege_escalation]
 become = True

--- a/ansible/netbox_inventory.yml
+++ b/ansible/netbox_inventory.yml
@@ -1,0 +1,14 @@
+plugin: netbox.netbox.nb_inventory
+api_endpoint: "{{ lookup('env', 'NETBOX_API_ENDPOINT') }}"
+token: "{{ lookup('env', 'NETBOX_API_TOKEN') }}"
+validate_certs: false
+groupby_custom_field:
+  - service
+compose:
+  ansible_host: >-
+    {{ primary_ip.address if primary_ip is not none else '' }}
+  environment_service: >-
+    {{ custom_fields.environment ~ '_' ~ custom_fields.service if (custom_fields.environment is defined and custom_fields.service is defined) else None }}
+keyed_groups:
+  - key: environment_service
+    prefix: ''

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -8,3 +8,5 @@ collections:
     version: ">=3.0.0"
   - name: chocolatey.chocolatey
     version: ">=1.0.0"
+  - name: netbox.netbox
+    version: ">=3.14.0"


### PR DESCRIPTION
## Summary
- add dynamic inventory configuration for NetBox
- enable NetBox inventory plugin
- add netbox.netbox collection dependency

## Testing
- `./scripts/run-lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_68891485908883229c17ba2090443db7