### PR TITLE
Add Docker cleanup workflow

### DIFF
--- a/.github/workflows/cleanup_docker.yml
+++ b/.github/workflows/cleanup_docker.yml
@@ -1,0 +1,27 @@
+---
+name: Docker Cleanup
+
+'on':
+  schedule:
+    - cron: '15 3 * * 0'
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: self-hosted
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Ansible
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ansible
+
+      - name: Install Ansible collections
+        run: ansible-galaxy collection install -r ansible/requirements.yml
+
+      - name: Execute cleanup playbook
+        working-directory: ansible
+        run: |
+          ansible-playbook playbooks/docker_cleanup.yml -i inventories/production/hosts.yml --become

--- a/ansible/playbooks/docker_cleanup.yml
+++ b/ansible/playbooks/docker_cleanup.yml
@@ -1,0 +1,21 @@
+---
+- name: Clean up Docker resources
+  hosts: all
+  become: true
+  tasks:
+    - name: Remove stopped containers
+      community.docker.docker_prune:
+        containers: true
+      changed_when: false
+
+    - name: Remove unused images
+      community.docker.docker_prune:
+        images: true
+        images_filters:
+          dangling: false
+      changed_when: false
+
+    - name: Remove unused networks
+      community.docker.docker_prune:
+        networks: true
+      changed_when: false


### PR DESCRIPTION
## Summary
- add workflow to clean up Docker objects weekly or manually
- add playbook for Docker cleanup with `community.docker.docker_prune`

## Testing
- `./scripts/run-lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a7913241c83228a3463f25a5756cb