### PR TITLE
Add k3s installation role and playbook

### DIFF
--- a/ansible/playbooks/install_k3s.yml
+++ b/ansible/playbooks/install_k3s.yml
@@ -1,0 +1,6 @@
+---
+- name: Install and configure k3s
+  hosts: k3s
+  become: true
+  roles:
+    - k3s

--- a/ansible/playbooks/roles/k3s/tasks/main.yml
+++ b/ansible/playbooks/roles/k3s/tasks/main.yml
@@ -1,0 +1,25 @@
+# ansible/playbooks/roles/k3s/tasks/main.yml
+---
+- name: Check if k3s is already installed
+  ansible.builtin.stat:
+    path: /usr/local/bin/k3s
+  register: k3s_binary
+
+- name: Download k3s install script
+  ansible.builtin.get_url:
+    url: https://get.k3s.io
+    dest: /tmp/k3s_install.sh
+    mode: '0755'
+  when: not k3s_binary.stat.exists
+
+- name: Install k3s
+  ansible.builtin.command:
+    cmd: /tmp/k3s_install.sh
+    creates: /usr/local/bin/k3s
+  when: not k3s_binary.stat.exists
+
+- name: Ensure k3s service is enabled and running
+  ansible.builtin.systemd:
+    name: k3s
+    enabled: true
+    state: started


### PR DESCRIPTION
## Summary
- add k3s role that installs k3s and enables service
- add playbook to apply k3s role

## Testing
- `ansible-lint ansible/playbooks/install_k3s.yml`


------
https://chatgpt.com/codex/tasks/task_e_6890f72a3bc4832281587afc9d4b79a6