### PR TITLE
Add k3s deployment workflow

### DIFF
--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -1,0 +1,48 @@
+---
+name: Deploy k3s
+
+'on':
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+  schedule:
+    - cron: '10 2 * * 2'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install Ansible and ansible-lint
+        run: |
+          pip install ansible ansible-lint
+      - name: Run ansible-lint
+        env:
+          ANSIBLE_CONFIG: ansible/ansible.cfg
+        run: ansible-lint ansible/
+
+  deploy:
+    needs: lint
+    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: self-hosted
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install Ansible
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ansible
+      - name: Install Ansible collections
+        run: ansible-galaxy collection install -r ansible/requirements.yml
+      - name: Execute playbook
+        working-directory: ansible
+        env:
+          ANSIBLE_DISPLAY_ARGS_TO_STDOUT: 'false'
+        run: |
+          ansible-playbook playbooks/install_k3s.yml -i inventories/production/hosts.yml --become


### PR DESCRIPTION
## Summary
- add GitHub Actions pipeline to deploy k3s role manually, on push, and weekly schedule

## Testing
- `scripts/run-lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_6891072cb6e48322ac347962f273edb0