### PR TITLE
Add k3s group to production inventory

### DIFF
--- a/ansible/inventories/production/hosts.yml
+++ b/ansible/inventories/production/hosts.yml
@@ -10,3 +10,7 @@ pcloud:
 netbox:
   hosts:
     localhost:
+
+k3s:
+  hosts:
+    localhost:


### PR DESCRIPTION
## Summary
- include k3s group in production inventory so install_k3s playbook has matching hosts

## Testing
- `ansible-lint playbooks/install_k3s.yml`
- `ansible-playbook playbooks/install_k3s.yml -i inventories/production/hosts.yml --become --list-hosts`


------
https://chatgpt.com/codex/tasks/task_e_6891163ba64c832298dfaaf2c41ee00b