### PR TITLE
Remove redundant lint from deployment workflows

### DIFF
--- a/.github/workflows/deploy-apt.yml
+++ b/.github/workflows/deploy-apt.yml
@@ -11,26 +11,7 @@ name: Apply Updates
       - 'ansible/playbooks/apply_updates.yml'
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-      - name: Install Ansible and ansible-lint
-        run: |
-          pip install ansible ansible-lint
-      - name: Run ansible-lint
-        env:
-          ANSIBLE_CONFIG: ansible/ansible.cfg
-        run: ansible-lint ansible/
-
   deploy:
-    needs: lint
-    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: self-hosted
     steps:
       - name: Checkout repository
@@ -44,4 +25,5 @@ jobs:
       - name: Execute apply_updates playbook
         working-directory: ansible
         run: |
-          ansible-playbook playbooks/apply_updates.yml -i inventories/production/hosts.yml --become
+          ansible-playbook playbooks/apply_updates.yml \
+            -i inventories/production/hosts.yml --become

--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -10,26 +10,7 @@ name: Deploy Dashboard
     - cron: '15 5 * * 0'
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-      - name: Install Ansible and ansible-lint
-        run: |
-          pip install ansible ansible-lint
-      - name: Run ansible-lint
-        env:
-          ANSIBLE_CONFIG: ansible/ansible.cfg
-        run: ansible-lint ansible/
-
   deploy:
-    needs: lint
-    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: self-hosted
     steps:
       - name: Checkout repository

--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -10,26 +10,7 @@ name: Deploy k3s
     - cron: '10 2 * * 2'
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-      - name: Install Ansible and ansible-lint
-        run: |
-          pip install ansible ansible-lint
-      - name: Run ansible-lint
-        env:
-          ANSIBLE_CONFIG: ansible/ansible.cfg
-        run: ansible-lint ansible/
-
   deploy:
-    needs: lint
-    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: self-hosted
     steps:
       - name: Checkout repository
@@ -45,4 +26,5 @@ jobs:
         env:
           ANSIBLE_DISPLAY_ARGS_TO_STDOUT: 'false'
         run: |
-          ansible-playbook playbooks/install_k3s.yml -i inventories/production/hosts.yml --become
+          ansible-playbook playbooks/install_k3s.yml \
+            -i inventories/production/hosts.yml --become

--- a/.github/workflows/deploy-netbox.yml
+++ b/.github/workflows/deploy-netbox.yml
@@ -11,26 +11,7 @@ name: Deploy NetBox
     - cron: '25 3 * * 1'
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-      - name: Install Ansible and ansible-lint
-        run: |
-          pip install ansible ansible-lint
-      - name: Run ansible-lint
-        env:
-          ANSIBLE_CONFIG: ansible/ansible.cfg
-        run: ansible-lint ansible/
-
   deploy:
-    needs: lint
-    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: self-hosted
     steps:
       - name: Checkout repository
@@ -49,6 +30,9 @@ jobs:
           NETBOX_SECRET_KEY: ${{ secrets.NETBOX_SECRET_KEY }}
           ANSIBLE_DISPLAY_ARGS_TO_STDOUT: 'false'
         run: |
-          ansible-playbook playbooks/install_netbox.yml -i inventories/production/hosts.yml \
-            -e "netbox_db_password=${NETBOX_DB_PASSWORD} netbox_redis_password=${NETBOX_REDIS_PASSWORD} netbox_secret_key=${NETBOX_SECRET_KEY}" \
+          ansible-playbook playbooks/install_netbox.yml \
+            -i inventories/production/hosts.yml \
+            -e "netbox_db_password=${NETBOX_DB_PASSWORD}" \
+            -e "netbox_redis_password=${NETBOX_REDIS_PASSWORD}" \
+            -e "netbox_secret_key=${NETBOX_SECRET_KEY}" \
             --become

--- a/.github/workflows/deploy-pcloud.yml
+++ b/.github/workflows/deploy-pcloud.yml
@@ -10,26 +10,7 @@ name: Deploy pCloud
     - cron: '20 2 * * 1'
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-      - name: Install Ansible and ansible-lint
-        run: |
-          pip install ansible ansible-lint
-      - name: Run ansible-lint
-        env:
-          ANSIBLE_CONFIG: ansible/ansible.cfg
-        run: ansible-lint ansible/
-
   deploy:
-    needs: lint
-    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: self-hosted
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- simplify deployment workflows by dropping unnecessary lint jobs

## Testing
- `scripts/run-lint.sh` *(fails: Failed to load playbooks/install_dashboard.yml)*

------
https://chatgpt.com/codex/tasks/task_e_68912fc730308322b174ea618a78a560