### PR TITLE
feat: add Portainer role

### DIFF
--- a/.github/workflows/deploy-portainer.yml
+++ b/.github/workflows/deploy-portainer.yml
@@ -1,0 +1,31 @@
+---
+name: Deploy Portainer
+
+'on':
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+  schedule:
+    - cron: '25 3 * * 1'
+
+jobs:
+  deploy:
+    runs-on: self-hosted
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install Ansible
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ansible
+      - name: Install Ansible collections
+        run: ansible-galaxy collection install -r ansible/requirements.yml
+      - name: Execute playbook
+        working-directory: ansible
+        env:
+          ANSIBLE_DISPLAY_ARGS_TO_STDOUT: 'false'
+        run: |
+          ansible-playbook playbooks/install_portainer.yml \
+            -i inventories/production/hosts.yml \
+            --become

--- a/ansible/inventories/production/hosts.yml
+++ b/ansible/inventories/production/hosts.yml
@@ -7,6 +7,10 @@ pcloud:
   hosts:
     localhost:
 
+portainer:
+  hosts:
+    localhost:
+
 netbox:
   hosts:
     localhost:

--- a/ansible/playbooks/install_portainer.yml
+++ b/ansible/playbooks/install_portainer.yml
@@ -1,0 +1,6 @@
+---
+- name: Install and configure Portainer
+  hosts: portainer
+  become: true
+  roles:
+    - portainer

--- a/ansible/playbooks/roles/portainer/defaults/main.yml
+++ b/ansible/playbooks/roles/portainer/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+portainer_dir: "/opt/portainer"
+portainer_image: "portainer/portainer-ce:latest"
+portainer_port: 9443
+portainer_edge_port: 8000
+portainer_data_volume: "portainer-data"

--- a/ansible/playbooks/roles/portainer/readme.md
+++ b/ansible/playbooks/roles/portainer/readme.md
@@ -1,0 +1,15 @@
+# Portainer Role
+
+Deploys [Portainer](https://www.portainer.io/) using Docker Compose.
+
+## Variables
+
+- `portainer_image`: Docker image to deploy (default `portainer/portainer-ce:latest`)
+- `portainer_dir`: Directory for the compose file (default `/opt/portainer`)
+- `portainer_port`: Host port for the HTTPS UI (default `9443`)
+- `portainer_edge_port`: Host port for the Edge agent (default `8000`)
+- `portainer_data_volume`: Named volume for Portainer data (default `portainer-data`)
+
+The role always pulls the image before launching the stack so the container is updated to the latest version on each run.
+
+Ports are bound to the ZeroTier interface's IP address so the service is only accessible over ZeroTier.

--- a/ansible/playbooks/roles/portainer/tasks/main.yml
+++ b/ansible/playbooks/roles/portainer/tasks/main.yml
@@ -1,0 +1,48 @@
+---
+- name: Detect ZeroTier interface
+  ansible.builtin.set_fact:
+    portainer_zerotier_interface: >-
+      {{
+        ansible_interfaces
+        | select('match', '^zt')
+        | list
+        | first
+        | default('')
+      }}
+
+- name: Fail if ZeroTier interface not found
+  ansible.builtin.fail:
+    msg: "No ZeroTier interface found"
+  when: portainer_zerotier_interface | length == 0
+
+- name: Gather ZeroTier IP address
+  ansible.builtin.set_fact:
+    portainer_zerotier_ip: >-
+      {{
+        hostvars[inventory_hostname]
+        ['ansible_' ~ portainer_zerotier_interface]
+        ['ipv4']['address']
+      }}
+
+- name: Ensure Portainer directory exists
+  ansible.builtin.file:
+    path: "{{ portainer_dir }}"
+    state: directory
+    mode: '0755'
+
+- name: Deploy docker-compose file
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
+    dest: "{{ portainer_dir }}/docker-compose.yml"
+    mode: '0644'
+
+- name: Launch Portainer stack
+  community.docker.docker_compose_v2:
+    project_src: "{{ portainer_dir }}"
+    state: present
+    pull: always
+  register: portainer_compose
+
+- name: Display compose status
+  ansible.builtin.debug:
+    var: portainer_compose

--- a/ansible/playbooks/roles/portainer/templates/docker-compose.yml.j2
+++ b/ansible/playbooks/roles/portainer/templates/docker-compose.yml.j2
@@ -1,0 +1,12 @@
+services:
+  portainer:
+    image: {{ portainer_image }}
+    restart: unless-stopped
+    ports:
+      - "{{ portainer_zerotier_ip }}:{{ portainer_port }}:9443"
+      - "{{ portainer_zerotier_ip }}:{{ portainer_edge_port }}:8000"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - {{ portainer_data_volume }}:/data
+volumes:
+  {{ portainer_data_volume }}:


### PR DESCRIPTION
## Summary
- add Portainer role with docker-compose deployment
- run Portainer playbook via new GitHub Actions workflow
- register Portainer hosts in inventory

## Testing
- `./scripts/run-lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_6893248a328c832290954278af12baaf