### PR TITLE
Add Trivy security scanning

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,20 @@
+name: Security Scan
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  trivy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@v0.14.0
+        with:
+          scan-type: fs
+          security-checks: vuln,config,secret
+          ignore-unfixed: true
+          exit-code: '1'
+          severity: HIGH,CRITICAL

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Generated locally – never commit
 docker-compose.override.yml
+
+# Trivy cache
+.trivy-cache/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: scan
+
+scan:
+	docker run --rm -v $$PWD:/project -v $$PWD/.trivy-cache:/root/.cache/ aquasec/trivy:0.50.1 fs --exit-code 1 --severity HIGH,CRITICAL /project

--- a/README.security.md
+++ b/README.security.md
@@ -1,0 +1,21 @@
+# Sécurité – Trivy
+
+Ce dépôt inclut une configuration pour analyser les vulnérabilités, les erreurs de configuration et les secrets grâce à [Trivy](https://github.com/aquasecurity/trivy).
+
+## Scan local
+
+```bash
+make scan
+```
+
+Cette commande lance le conteneur `aquasec/trivy` en mode *filesystem* sur le projet. Le cache est stocké dans le dossier `.trivy-cache/`.
+
+Vous pouvez également utiliser docker compose :
+
+```bash
+docker compose -f docker-compose.security.yml run --rm trivy
+```
+
+## Intégration CI
+
+Le workflow GitHub [`security.yml`](.github/workflows/security.yml) exécute automatiquement un scan Trivy sur chaque `push` et `pull request`. Le job échouera si des vulnérabilités de sévérité `HIGH` ou `CRITICAL` sont trouvées.

--- a/docker-compose.security.yml
+++ b/docker-compose.security.yml
@@ -1,0 +1,8 @@
+version: "3.9"
+services:
+  trivy:
+    image: aquasec/trivy:0.50.1
+    command: fs --exit-code 1 --severity HIGH,CRITICAL /project
+    volumes:
+      - ./:/project:ro
+      - ./.trivy-cache:/root/.cache/


### PR DESCRIPTION
## Summary
- add Makefile and docker compose file to run Trivy vulnerability scans
- document security scanning in README.security.md
- run Trivy scan in CI via GitHub Actions

## Testing
- `make scan` *(fails: docker: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68965cbc8d9883229bce44b836c1951a