### PR TITLE
fix: update trivy action version

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.14.0
+        uses: aquasecurity/trivy-action@0.32.0
         with:
           scan-type: fs
           security-checks: vuln,config,secret


### PR DESCRIPTION
## Summary
- update trivy GitHub Action to the latest release

## Testing
- `make scan` *(fails: docker: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896603a05e483229a3008fdc372c285