### PR TITLE
chore: wrap long Jinja expressions

### DIFF
--- a/ansible/netbox_inventory.yml
+++ b/ansible/netbox_inventory.yml
@@ -8,7 +8,10 @@ compose:
   ansible_host: >-
     {{ primary_ip.address if primary_ip is not none else '' }}
   environment_service: >-
-    {{ custom_fields.environment ~ '_' ~ custom_fields.service if (custom_fields.environment is defined and custom_fields.service is defined) else None }}
+    {{ custom_fields.environment ~ '_' ~ custom_fields.service
+       if (custom_fields.environment is defined and
+           custom_fields.service is defined)
+       else None }}
 keyed_groups:
   - key: environment_service
     prefix: ''

--- a/ansible/playbooks/roles/dashboard/tasks/main.yml
+++ b/ansible/playbooks/roles/dashboard/tasks/main.yml
@@ -1,7 +1,10 @@
 ---
 - name: Detect ZeroTier interface
   ansible.builtin.set_fact:
-    dashboard_zerotier_interface: "{{ ansible_interfaces | select('match', '^zt') | list | first | default('') }}"
+    dashboard_zerotier_interface: >-
+      {{ ansible_interfaces
+         | select('match', '^zt')
+         | list | first | default('') }}
 
 - name: Fail if ZeroTier interface not found
   ansible.builtin.fail:
@@ -10,7 +13,9 @@
 
 - name: Gather ZeroTier IP address
   ansible.builtin.set_fact:
-    dashboard_zerotier_ip: "{{ hostvars[inventory_hostname]['ansible_' ~ dashboard_zerotier_interface]['ipv4']['address'] }}"
+    dashboard_zerotier_ip: >-
+      {{ hostvars[inventory_hostname]['ansible_' ~ dashboard_zerotier_interface]
+         ['ipv4']['address'] }}
 
 - name: Ensure Dashboard directory exists
   ansible.builtin.file:


### PR DESCRIPTION
## Summary
- wrap long Jinja expressions in netbox inventory
- wrap long Jinja expressions in dashboard role

## Testing
- `./scripts/run-lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_6896fb2a3ab4832286413597bfd84078