### PR TITLE
Add YubiKey SSH role

### DIFF
--- a/ansible/playbooks/install_yubikey.yml
+++ b/ansible/playbooks/install_yubikey.yml
@@ -1,0 +1,6 @@
+---
+- name: Install and configure YubiKey for SSH
+  hosts: yubikey
+  become: true
+  roles:
+    - yubikey

--- a/ansible/playbooks/roles/yubikey/defaults/main.yml
+++ b/ansible/playbooks/roles/yubikey/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+yubikey_authfile: /etc/yubico/u2f_keys
+yubikey_mappings: []

--- a/ansible/playbooks/roles/yubikey/handlers/main.yml
+++ b/ansible/playbooks/roles/yubikey/handlers/main.yml
@@ -1,0 +1,7 @@
+# ansible/playbooks/roles/yubikey/handlers/main.yml
+---
+- name: Reload sshd
+  ansible.builtin.systemd:
+    name: ssh
+    state: reloaded
+  become: true

--- a/ansible/playbooks/roles/yubikey/tasks/main.yml
+++ b/ansible/playbooks/roles/yubikey/tasks/main.yml
@@ -1,0 +1,63 @@
+# ansible/playbooks/roles/yubikey/tasks/main.yml
+---
+- name: Install YubiKey dependencies
+  ansible.builtin.apt:
+    name:
+      - libpam-u2f
+      - pcscd
+    state: present
+    update_cache: true
+  become: true
+
+- name: Ensure directory for U2F mappings exists
+  ansible.builtin.file:
+    path: "{{ yubikey_authfile | dirname }}"
+    state: directory
+    mode: '0755'
+  become: true
+
+- name: Ensure U2F mappings file exists
+  ansible.builtin.file:
+    path: "{{ yubikey_authfile }}"
+    state: touch
+    mode: '0600'
+    owner: root
+    group: root
+  become: true
+
+- name: Deploy U2F mappings if provided
+  ansible.builtin.copy:
+    dest: "{{ yubikey_authfile }}"
+    content: "{{ (yubikey_mappings | join('\n')) ~ '\n' }}"
+    mode: '0600'
+    owner: root
+    group: root
+  when: yubikey_mappings | length > 0
+  become: true
+
+- name: Configure PAM for U2F
+  ansible.builtin.lineinfile:
+    path: /etc/pam.d/sshd
+    regexp: '^auth\s+required\s+pam_u2f\.so'
+    line: "auth required pam_u2f.so authfile={{ yubikey_authfile }}"
+    insertafter: '^@include common-auth'
+  notify: Reload sshd
+  become: true
+
+- name: Enable ChallengeResponseAuthentication
+  ansible.builtin.lineinfile:
+    path: /etc/ssh/sshd_config
+    regexp: '^ChallengeResponseAuthentication'
+    line: 'ChallengeResponseAuthentication yes'
+    state: present
+  notify: Reload sshd
+  become: true
+
+- name: Require both public key and U2F for SSH
+  ansible.builtin.lineinfile:
+    path: /etc/ssh/sshd_config
+    regexp: '^AuthenticationMethods'
+    line: 'AuthenticationMethods publickey,keyboard-interactive'
+    state: present
+  notify: Reload sshd
+  become: true


### PR DESCRIPTION
## Summary
- add YubiKey role to enable U2F authentication for SSH
- support configuring U2F mappings and SSH PAM settings

## Testing
- `ansible-playbook ansible/playbooks/install_yubikey.yml --syntax-check`
- `ansible-lint ansible/playbooks/install_yubikey.yml`


------
https://chatgpt.com/codex/tasks/task_e_68bd46b003508322888dc7aef655897d