### PR TITLE
Add YubiKey deployment workflow and clean up role

### DIFF
--- a/.github/workflows/deploy-yubikey.yml
+++ b/.github/workflows/deploy-yubikey.yml
@@ -1,0 +1,31 @@
+---
+name: Deploy YubiKey
+
+'on':
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+  schedule:
+    - cron: '45 2 * * 3'
+
+jobs:
+  deploy:
+    runs-on: self-hosted
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install Ansible
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ansible
+      - name: Install Ansible collections
+        run: ansible-galaxy collection install -r ansible/requirements.yml
+      - name: Execute playbook
+        working-directory: ansible
+        env:
+          ANSIBLE_DISPLAY_ARGS_TO_STDOUT: 'false'
+        run: |
+          ansible-playbook playbooks/install_yubikey.yml \
+            -i inventories/production/hosts.yml \
+            --become

--- a/ansible/playbooks/roles/yubikey/handlers/main.yml
+++ b/ansible/playbooks/roles/yubikey/handlers/main.yml
@@ -1,4 +1,3 @@
-# ansible/playbooks/roles/yubikey/handlers/main.yml
 ---
 - name: Reload sshd
   ansible.builtin.systemd:

--- a/ansible/playbooks/roles/yubikey/readme.md
+++ b/ansible/playbooks/roles/yubikey/readme.md
@@ -1,0 +1,10 @@
+# YubiKey Role
+
+Installs and configures YubiKey U2F authentication for SSH.
+
+## Variables
+
+- `yubikey_authfile`: Path to the U2F mappings file (default `/etc/yubico/u2f_keys`)
+- `yubikey_mappings`: List of YubiKey mappings to deploy (default `[]`)
+
+Store sensitive mapping values outside of version control if required.

--- a/ansible/playbooks/roles/yubikey/tasks/main.yml
+++ b/ansible/playbooks/roles/yubikey/tasks/main.yml
@@ -1,4 +1,3 @@
-# ansible/playbooks/roles/yubikey/tasks/main.yml
 ---
 - name: Install YubiKey dependencies
   ansible.builtin.apt:


### PR DESCRIPTION
## Summary
- align YubiKey role formatting with other roles
- document YubiKey role variables
- add GitHub Actions workflow to deploy YubiKey playbook

## Testing
- `pip install ansible ansible-lint yamllint`
- `ansible-galaxy collection install -r ansible/requirements.yml`
- `yamllint -d '{extends: relaxed}' .`
- `ANSIBLE_CONFIG=ansible/ansible.cfg ansible-lint ansible`


------
https://chatgpt.com/codex/tasks/task_e_68bd500e2f088322a81db0578ccd348a