### PR TITLE
Fix fail2ban uninstall target and remove install playbook

### DIFF
--- a/ansible/inventories/production/hosts.yml
+++ b/ansible/inventories/production/hosts.yml
@@ -22,3 +22,7 @@ k3s:
 yubikey:
   hosts:
     localhost:
+
+fail2ban:
+  hosts:
+    localhost:

--- a/ansible/playbooks/install_fail2ban.yml
+++ b/ansible/playbooks/install_fail2ban.yml
@@ -1,6 +1,0 @@
----
-- name: Install and configure Fail2ban
-  hosts: fail2ban
-  become: true
-  roles:
-    - fail2ban

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -10,7 +10,6 @@
 
 # - import_playbook: playbooks/install_docker.yml
 # - import_playbook: playbooks/install_ufw.yml
-# - import_playbook: playbooks/install_fail2ban.yml
 # - import_playbook: playbooks/install_pcloud.yml
 # - import_playbook: playbooks/install_zerotier.yml
 # - import_playbook: playbooks/install_bind_dns.yml


### PR DESCRIPTION
## Summary
- add a fail2ban host group in the production inventory so the uninstall playbook matches localhost
- remove the unused Fail2ban installation playbook reference from the master playbook
- delete the obsolete Fail2ban installation playbook file

## Testing
- ansible-playbook -i inventories/production/hosts.yml playbooks/uninstall_fail2ban.yml --syntax-check *(not run: ansible-playbook not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920d55589f8832293316621c46aaf5c)