### PR TITLE
Refactor Debian setup script into structured helper functions

### DIFF
--- a/scripts/setup-debian.sh
+++ b/scripts/setup-debian.sh
@@ -2,7 +2,6 @@
 # Install Docker and Fail2ban on Debian-based systems
 set -euo pipefail
 
-# Optional repository URL to clone
 REPO_URL="${1:-}"
 
 if [ "$(id -u)" -ne 0 ]; then
@@ -11,52 +10,80 @@ else
     SUDO=''
 fi
 
-$SUDO apt-get update
-$SUDO apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release software-properties-common git
+log() {
+    echo "[setup-debian] $*"
+}
 
-if [ -n "$REPO_URL" ]; then
-    git clone "$REPO_URL"
-fi
+run() {
+    if [ -n "$SUDO" ]; then
+        "$SUDO" "$@"
+    else
+        "$@"
+    fi
+}
 
-# Install Docker if not present
-if ! command -v docker >/dev/null 2>&1; then
-    $SUDO install -m 0755 -d /etc/apt/keyrings
-    curl -fsSL https://download.docker.com/linux/debian/gpg | $SUDO gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-    $SUDO chmod a+r /etc/apt/keyrings/docker.gpg
+install_base_packages() {
+    log "Updating apt cache and installing prerequisites"
+    run apt-get update
+    run apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release software-properties-common git
+}
+
+clone_repository_if_requested() {
+    if [ -n "$REPO_URL" ]; then
+        log "Cloning repository: $REPO_URL"
+        git clone "$REPO_URL"
+    fi
+}
+
+configure_docker_repository() {
+    run install -m 0755 -d /etc/apt/keyrings
+    curl -fsSL https://download.docker.com/linux/debian/gpg | run gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+    run chmod a+r /etc/apt/keyrings/docker.gpg
 
     if [ ! -f /etc/apt/sources.list.d/docker.list ]; then
-        echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | $SUDO tee /etc/apt/sources.list.d/docker.list > /dev/null
+        log "Adding Docker apt repository"
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | run tee /etc/apt/sources.list.d/docker.list > /dev/null
+    fi
+}
+
+install_docker() {
+    if command -v docker >/dev/null 2>&1; then
+        log "Docker already installed; skipping"
+        return
     fi
 
-    $SUDO apt-get update
-    $SUDO apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+    log "Installing Docker"
+    configure_docker_repository
+    run apt-get update
+    run apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+    run systemctl enable --now docker
 
-    # Enable Docker service
-    $SUDO systemctl enable --now docker
-
-    # Add current user to docker group if not root
     if [ "$(id -u)" -ne 0 ]; then
-        $SUDO usermod -aG docker "$USER"
+        run usermod -aG docker "$USER"
     fi
-fi
 
-echo "Docker installation complete."
+    log "Docker installation complete"
+}
 
-# Install Fail2ban if not present
-if ! dpkg -s fail2ban >/dev/null 2>&1; then
-    $SUDO apt-get install -y fail2ban
-fi
+install_fail2ban() {
+    if ! dpkg -s fail2ban >/dev/null 2>&1; then
+        log "Installing Fail2ban"
+        run apt-get install -y fail2ban
+    else
+        log "Fail2ban already installed"
+    fi
+}
 
-
-# Minimal Fail2ban configuration
-$SUDO tee /etc/fail2ban/fail2ban.conf >/dev/null <<'EOF'
+configure_fail2ban() {
+    log "Configuring Fail2ban"
+    run tee /etc/fail2ban/fail2ban.conf >/dev/null <<'CONF'
 [DEFAULT]
 loglevel = INFO
 logtarget = SYSLOG
 backend = systemd
-EOF
+CONF
 
-$SUDO tee /etc/fail2ban/jail.local >/dev/null <<'EOF'
+    run tee /etc/fail2ban/jail.local >/dev/null <<'CONF'
 [DEFAULT]
 backend = systemd
 bantime = 3600
@@ -65,10 +92,18 @@ maxretry = 5
 [sshd]
 enabled = true
 filter = sshd
-EOF
+CONF
 
-# Enable Fail2ban service
-$SUDO systemctl enable --now fail2ban
+    run systemctl enable --now fail2ban
+    log "Fail2ban installation complete"
+}
 
-echo "Fail2ban installation complete."
+main() {
+    install_base_packages
+    clone_repository_if_requested
+    install_docker
+    install_fail2ban
+    configure_fail2ban
+}
 
+main


### PR DESCRIPTION
### Motivation
- Improve readability and maintainability by refactoring the long linear `scripts/setup-debian.sh` into focused helper functions.
- Centralize privileged execution and logging to reduce duplication and clarify which commands require `sudo`.
- Preserve the original behavior (conditional Docker/Fail2ban installs, service enablement, and user group changes) while making the flow easier to extend.

### Description
- Introduced `log` and `run` helpers where `run` wraps commands with `sudo` when necessary and `log` prefixes messages with `[setup-debian]`.
- Extracted main steps into functions: `install_base_packages`, `clone_repository_if_requested`, `configure_docker_repository`, `install_docker`, `install_fail2ban`, `configure_fail2ban`, and `main`.
- Replaced inline `sudo` command invocations with `run` calls and kept existing behavior such as adding the user to the `docker` group and enabling services with `systemctl`.
- Kept Fail2ban configuration via here-documents and moved repository configuration logic into `configure_docker_repository`.

### Testing
- Ran `bash -n scripts/setup-debian.sh` to perform a shell syntax check, which succeeded.
- Attempted to run `shellcheck scripts/setup-debian.sh` but `shellcheck` is not installed in the environment so static linting was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998746ff9b08322b0e80f585fc1af81)