### PR TITLE
Make lint script fail when linters are missing and add regression tests

### DIFF
--- a/scripts/run-lint.sh
+++ b/scripts/run-lint.sh
@@ -2,11 +2,14 @@
 # Run yamllint and ansible-lint with project configuration
 set -euo pipefail
 
+missing_tools=0
+
 # Run yamllint using relaxed rules
 if command -v yamllint >/dev/null 2>&1; then
     yamllint -d "{extends: relaxed}" .
 else
     echo "yamllint is not installed" >&2
+    missing_tools=1
 fi
 
 # Run ansible-lint using local ansible.cfg
@@ -14,5 +17,9 @@ if command -v ansible-lint >/dev/null 2>&1; then
     ANSIBLE_CONFIG=ansible/ansible.cfg ansible-lint "$@"
 else
     echo "ansible-lint is not installed" >&2
+    missing_tools=1
 fi
 
+if [ "$missing_tools" -ne 0 ]; then
+    exit 1
+fi

--- a/scripts/tests/run-lint.test.sh
+++ b/scripts/tests/run-lint.test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/run-lint.sh"
+
+assert_contains() {
+    local haystack="$1"
+    local needle="$2"
+
+    if [[ "$haystack" != *"$needle"* ]]; then
+        echo "Assertion failed: expected output to contain '$needle'"
+        echo "Actual output:"
+        printf '%s\n' "$haystack"
+        exit 1
+    fi
+}
+
+test_fails_when_lint_tools_are_missing() {
+    local temp_path
+    temp_path="$(mktemp -d)"
+
+    set +e
+    local output
+    output="$(PATH="$temp_path" "$SCRIPT" 2>&1)"
+    local exit_code=$?
+    set -e
+
+    rm -rf "$temp_path"
+
+    if [ "$exit_code" -eq 0 ]; then
+        echo "Expected non-zero exit code when lint tools are missing"
+        exit 1
+    fi
+
+    assert_contains "$output" "yamllint is not installed"
+    assert_contains "$output" "ansible-lint is not installed"
+}
+
+test_runs_both_linters_when_available() {
+    local temp_path
+    temp_path="$(mktemp -d)"
+
+    cat > "$temp_path/yamllint" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "yamllint:$*"
+SH
+
+    cat > "$temp_path/ansible-lint" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "ansible-lint:$*|ANSIBLE_CONFIG=${ANSIBLE_CONFIG:-unset}"
+SH
+
+    chmod +x "$temp_path/yamllint" "$temp_path/ansible-lint"
+
+    local output
+    output="$(PATH="$temp_path:$PATH" "$SCRIPT" --offline 2>&1)"
+
+    rm -rf "$temp_path"
+
+    assert_contains "$output" "yamllint:-d {extends: relaxed} ."
+    assert_contains "$output" "ansible-lint:--offline|ANSIBLE_CONFIG=ansible/ansible.cfg"
+}
+
+test_fails_when_lint_tools_are_missing
+test_runs_both_linters_when_available
+
+echo "run-lint tests passed"


### PR DESCRIPTION
### Motivation
- Ensure CI and local checks fail loudly when required linting tools are not installed instead of silently returning success.

### Description
- Update `scripts/run-lint.sh` to track missing tools with a `missing_tools` flag and `exit 1` when `yamllint` or `ansible-lint` are not found.
- Preserve existing invocation behavior for `yamllint -d "{extends: relaxed}" .` and `ANSIBLE_CONFIG=ansible/ansible.cfg ansible-lint "$@"`.
- Add `scripts/tests/run-lint.test.sh` which exercises both the failure path (tools absent) and the success path using mocked `yamllint` and `ansible-lint` binaries.

### Testing
- Ran `scripts/tests/run-lint.test.sh` and it completed successfully (`run-lint tests passed`).
- Ran `./scripts/run-lint.sh` in the current environment and it exited non-zero while printing the expected "yamllint is not installed" and "ansible-lint is not installed" messages (behaviour intended when linters are absent).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998754571bc83229982dc51082b4a2a)